### PR TITLE
Add default fields to schema

### DIFF
--- a/FormSchemas/jsonschema.json
+++ b/FormSchemas/jsonschema.json
@@ -95,7 +95,6 @@
                 "xmax": 180,
                 "ymax": 90
             }
-            
         },
         "temporal_extent": {
             "title": "Temporal Extent",
@@ -111,7 +110,11 @@
                     "format": "date-time",
                     "title": "End Date"
                 }
-            }
+            },
+            "required": [
+                "startdate",
+                "enddate"
+            ]
         },
         "discovery_items": {
             "type": "array",
@@ -215,7 +218,7 @@
             "default": [
                 "https://stac-extensions.github.io/render/v1.0.0/schema.json",
                 "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
-              ]
+            ]
         },
         "item_assets": {
             "type": "object",

--- a/FormSchemas/jsonschema.json
+++ b/FormSchemas/jsonschema.json
@@ -350,7 +350,14 @@
                         "href",
                         "type",
                         "roles"
-                    ]
+                    ],
+                    "default": {
+                        "title": "Thumbnail",
+                        "type": "image/jpeg",
+                        "roles": [
+                            "thumbnail"
+                        ]
+                    }
                 }
             }
         }

--- a/FormSchemas/jsonschema.json
+++ b/FormSchemas/jsonschema.json
@@ -31,6 +31,11 @@
             "title": "License",
             "default": "CC0-1.0"
         },
+        "stac_version": {
+            "type": "string",
+            "title": "STAC Version",
+            "default": "1.0.0"
+        },
         "dashboard:is_periodic": {
             "type": "boolean",
             "title": "Is Periodic?"
@@ -110,11 +115,7 @@
                     "format": "date-time",
                     "title": "End Date"
                 }
-            },
-            "required": [
-                "startdate",
-                "enddate"
-            ]
+            }
         },
         "discovery_items": {
             "type": "array",

--- a/FormSchemas/jsonschema.json
+++ b/FormSchemas/jsonschema.json
@@ -28,7 +28,8 @@
         },
         "license": {
             "type": "string",
-            "title": "License"
+            "title": "License",
+            "default": "CC0-1.0"
         },
         "dashboard:is_periodic": {
             "type": "boolean",
@@ -87,7 +88,14 @@
                     "type": "number",
                     "title": "ymax"
                 }
+            },
+            "default": {
+                "xmin": -180,
+                "ymin": -90,
+                "xmax": 180,
+                "ymax": 90
             }
+            
         },
         "temporal_extent": {
             "title": "Temporal Extent",
@@ -203,7 +211,11 @@
             "type": "array",
             "items": {
                 "type": "string"
-            }
+            },
+            "default": [
+                "https://stac-extensions.github.io/render/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+              ]
         },
         "item_assets": {
             "type": "object",
@@ -290,7 +302,16 @@
                         "format": "uri"
                     }
                 }
-            }
+            },
+            "default": [
+                {
+                    "name": "NASA VEDA",
+                    "roles": [
+                        "host"
+                    ],
+                    "url": "https://www.earthdata.nasa.gov/dashboard/"
+                }
+            ]
         },
         "assets": {
             "type": "object",

--- a/FormSchemas/jsonschema.json
+++ b/FormSchemas/jsonschema.json
@@ -106,12 +106,12 @@
             "type": "object",
             "properties": {
                 "startdate": {
-                    "type": "string",
+                    "type": ["string", "null"],
                     "format": "date-time",
                     "title": "Start Date"
                 },
                 "enddate": {
-                    "type": "string",
+                    "type": ["string", "null"],
                     "format": "date-time",
                     "title": "End Date"
                 }

--- a/FormSchemas/uischema.json
+++ b/FormSchemas/uischema.json
@@ -1,166 +1,173 @@
 {
-  "ui:grid": [
-    {
-      "collection": 4,
-      "title": 4,
-      "license": 4,
-      "description": 12
-    },
-    {
-      "dashboard:is_periodic": 4,
-      "dashboard:time_density": 4,
-      "data_type": 4,
-      "spatial_extent": 6,
-      "temporal_extent": 6
-    },
-    {
-      "discovery_items": 24
-    },
-    {
-      "sample_files": 24
-    },
-    {
-      "renders": 12,
-      "stac_extensions": 12
-    },
-    {
-      "links": 24
-    },
-    {
-      "item_assets": 24
-    },
-    {
-      "providers": 24
-    },
-
-    {
-      "assets":24
-    }
-  ],
-  "spatial_extent": {
     "ui:grid": [
-      {
-        "xmin": 12,
-        "ymin": 12
-      },
-      {
-        "xmax": 12,
-        "ymax": 12
-      }
-    ]
-  },
-  "discovery_items": {
-    "items": {
-      "ui:grid": [
         {
-          "upload": 8,
-          "cogify": 8,
-          "dry_run": 8
+            "collection": 4,
+            "title": 4,
+            "license": 4,
+            "description": 12
         },
         {
-          "discovery": 8,
-          "prefix": 8,
-          "bucket": 8
+            "dashboard:is_periodic": 4,
+            "dashboard:time_density": 4,
+            "data_type": 4,
+            "spatial_extent": 6,
+            "temporal_extent": 6
         },
         {
-          "filename_regex": 12,
-          "datetime_range": 12
+            "discovery_items": 24
         },
         {
-          "stac_extensions": 12,
-          "links": 12
+            "sample_files": 24
         },
         {
-          "start_datetime": 8,
-          "end_datetime": 8,
-          "single_datetime": 8
+            "renders": 12,
+            "stac_extensions": 12
         },
         {
-          "id_regex": 8,
-          "id_template": 8,
-          "use_multithreading": 8
+            "links": 24
+        },
+        {
+            "item_assets": 24
+        },
+        {
+            "providers": 24
+        },
+        {
+            "assets": 24
         }
-      ]
-    }
-  },
-  "links": {
-    "items": {
-      "ui:grid": [
-        {
-          "href": 12,
-          "rel": 12
-        },
-        {
-          "type": 12,
-          "title": 12
-        },
-        {
-          "label:assets": 12
+    ],
+    "spatial_extent": {
+        "ui:grid": [
+            {
+                "xmin": 12,
+                "ymin": 12
+            },
+            {
+                "xmax": 12,
+                "ymax": 12
+            }
+        ]
+    },
+    "discovery_items": {
+        "items": {
+            "ui:grid": [
+                {
+                    "upload": 8,
+                    "cogify": 8,
+                    "dry_run": 8
+                },
+                {
+                    "discovery": 8,
+                    "prefix": 8,
+                    "bucket": 8
+                },
+                {
+                    "filename_regex": 12,
+                    "datetime_range": 12
+                },
+                {
+                    "stac_extensions": 12,
+                    "links": 12
+                },
+                {
+                    "start_datetime": 8,
+                    "end_datetime": 8,
+                    "single_datetime": 8
+                },
+                {
+                    "id_regex": 8,
+                    "id_template": 8,
+                    "use_multithreading": 8
+                }
+            ]
         }
-      ]
-    }
-  },
-  "item_assets": {
-    "cog_default": {
-      "ui:grid": [
-        {
-          "type": 12,
-          "roles": 12
-        },
-        {
-          "title": 12,
-          "description": 12
+    },
+    "links": {
+        "items": {
+            "ui:grid": [
+                {
+                    "href": 12,
+                    "rel": 12
+                },
+                {
+                    "type": 12,
+                    "title": 12
+                },
+                {
+                    "label:assets": 12
+                }
+            ]
         }
-      ]
-    }
-  },
-  "providers": {
-    "items": {
-      "ui:grid": [
-        {
-          "name": 12,
-          "description": 12
-        },
-        {
-          "roles": 12,
-          "url": 12
+    },
+    "item_assets": {
+        "cog_default": {
+            "ui:grid": [
+                {
+                    "type": 12,
+                    "roles": 12
+                },
+                {
+                    "title": 12,
+                    "description": 12
+                }
+            ]
         }
-      ]
-    }
-  },
-  "assets": {
-    "thumbnail": {
-      "ui:grid": [
-        {
-        "title": 12,
-        "description": 12
-        },
-        {
-          "href": 8,
-          "type": 8,
-          "roles": 8
+    },
+    "providers": {
+        "items": {
+            "ui:grid": [
+                {
+                    "name": 12,
+                    "description": 12
+                },
+                {
+                    "roles": 12,
+                    "url": 12
+                }
+            ]
         }
-      ]
+    },
+    "assets": {
+        "thumbnail": {
+            "ui:grid": [
+                {
+                    "title": 12,
+                    "description": 12
+                },
+                {
+                    "href": 8,
+                    "type": 8,
+                    "roles": 8
+                }
+            ]
+        }
+    },
+    "description": {
+        "ui:widget": "textarea",
+        "ui:options": {
+            "rows": 2
+        }
+    },
+    "renders": {
+        "ui:widget": "textarea",
+        "ui:options": {
+            "rows": 12
+        }
+    },
+    "temporal_extent": {
+        "startdate": {
+            "ui:widget": "text"
+        },
+        "enddate": {
+            "ui:widget": "text"
+        }
+    },
+    "ui:submitButtonOptions": {
+        "props": {
+            "color": "primary",
+            "variant": "solid",
+            "size": "large",
+            "block": "true"
+        }
     }
-  },
-  "description": {
-    "ui:widget": "textarea",
-    "ui:options": {
-      "rows": 2
-    }
-  },
-  "renders": {
-      "ui:widget": "textarea",
-      "ui:options": {
-        "rows": 12
-      }
-  },
-  "ui:submitButtonOptions": {
-    "props": {
-      "color": "primary",
-      "variant": "solid",
-      "size": "large",
-      "block": "true"
-    }
-  }
 }

--- a/FormSchemas/uischema.json
+++ b/FormSchemas/uischema.json
@@ -2,14 +2,15 @@
     "ui:grid": [
         {
             "collection": 4,
-            "title": 4,
-            "license": 4,
+            "title": 6,
+            "license": 2,
             "description": 12
         },
         {
-            "dashboard:is_periodic": 4,
-            "dashboard:time_density": 4,
-            "data_type": 4,
+          "stac_version": 3,
+            "dashboard:is_periodic": 3,
+            "dashboard:time_density": 3,
+            "data_type": 3,
             "spatial_extent": 6,
             "temporal_extent": 6
         },

--- a/__tests__/utils/FormHandlers.ts
+++ b/__tests__/utils/FormHandlers.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from "vitest";
+import { handleSubmit } from "@/utils/FormHandlers";
+import { IChangeEvent } from "@rjsf/core";
+import { RJSFSchema } from "@rjsf/utils";
+
+describe("handleSubmit", () => {
+  it("should convert empty startdate to null when field is missing", () => {
+    const formData = {
+      temporal_extent: {
+        enddate: "2025-02-03T23:59:59.000Z",
+      },
+    };
+
+    const mockSubmit = vi.fn();
+    handleSubmit({ formData } as unknown as IChangeEvent<any, RJSFSchema, any>, mockSubmit);
+
+    expect(mockSubmit).toHaveBeenCalledWith({
+      temporal_extent: {
+        startdate: null,
+        enddate: "2025-02-03T23:59:59.000Z",
+      },
+    });
+  });
+
+  it("should convert empty enddate to null when field is missing", () => {
+    const formData = {
+      temporal_extent: {
+        startdate: "2025-02-03T00:00:00.000Z",
+      },
+    };
+
+    const mockSubmit = vi.fn();
+    handleSubmit({ formData } as unknown as IChangeEvent<any, RJSFSchema, any>, mockSubmit);
+
+    expect(mockSubmit).toHaveBeenCalledWith({
+      temporal_extent: {
+        startdate: "2025-02-03T00:00:00.000Z",
+        enddate: null,
+      },
+    });
+  });
+
+  it("should correctly keep valid startdate and enddate values", () => {
+    const formData = {
+      temporal_extent: {
+        startdate: "2025-02-03T00:00:00.000Z",
+        enddate: "2025-02-03T23:59:59.999Z",
+      },
+    };
+
+    const mockSubmit = vi.fn();
+    handleSubmit({ formData } as unknown as IChangeEvent<any, RJSFSchema, any>, mockSubmit);
+
+    expect(mockSubmit).toHaveBeenCalledWith({
+      temporal_extent: {
+        startdate: "2025-02-03T00:00:00.000Z",
+        enddate: "2025-02-03T23:59:59.999Z",
+      },
+    });
+  });
+});

--- a/__tests__/utils/FormValidation.test.ts
+++ b/__tests__/utils/FormValidation.test.ts
@@ -54,6 +54,20 @@ describe("customValidate", () => {
     );
   });
 
+  it("should allow null for startdate and enddate", () => {
+    const formData = {
+      temporal_extent: {
+        startdate: null,
+        enddate: null,
+      },
+    };
+    const errors: any = { temporal_extent: {} };
+    customValidate(formData, errors);
+  
+    expect(errors.temporal_extent.startdate).toBeUndefined();
+    expect(errors.temporal_extent.enddate).toBeUndefined();
+  });
+
   it("should validate correct JSON in the 'renders' field", () => {
     const formData = { renders: '{"key": "value"}' };
     const errors: any = { renders: {} };

--- a/__tests__/utils/FormValidation.test.ts
+++ b/__tests__/utils/FormValidation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { customValidate } from "@/utils/formValidation";
+import { customValidate } from "@/utils/FormValidation";
 
 describe("customValidate", () => {
   it("should validate a correct RFC 3339 datetime format", () => {
@@ -16,6 +16,20 @@ describe("customValidate", () => {
     expect(errors.temporal_extent.enddate).toBeUndefined();
   });
 
+  it("should allow an empty string for startdate and enddate", () => {
+    const formData = {
+      temporal_extent: {
+        startdate: "",
+        enddate: "",
+      },
+    };
+    const errors: any = { temporal_extent: {} };
+    customValidate(formData, errors);
+
+    expect(errors.temporal_extent.startdate).toBeUndefined();
+    expect(errors.temporal_extent.enddate).toBeUndefined();
+  });
+
   it("should return an error for invalid RFC 3339 datetime format", () => {
     const formData = {
       temporal_extent: {
@@ -23,15 +37,20 @@ describe("customValidate", () => {
         enddate: "2025-02-03 23:59:59",
       },
     };
-    const errors: any = { temporal_extent: { startdate: { addError: vi.fn() }, enddate: { addError: vi.fn() } } };
+    const errors: any = {
+      temporal_extent: {
+        startdate: { addError: vi.fn() },
+        enddate: { addError: vi.fn() },
+      },
+    };
 
     customValidate(formData, errors);
 
     expect(errors.temporal_extent.startdate.addError).toHaveBeenCalledWith(
-      "Start Date must be in RFC 3339 format (YYYY-MM-DDTHH:mm:ss.sssZ)"
+      "Start Date must be in RFC 3339 format (YYYY-MM-DDTHH:mm:ss.sssZ) or empty."
     );
     expect(errors.temporal_extent.enddate.addError).toHaveBeenCalledWith(
-      "End Date must be in RFC 3339 format (YYYY-MM-DDTHH:mm:ss.sssZ)"
+      "End Date must be in RFC 3339 format (YYYY-MM-DDTHH:mm:ss.sssZ) or empty."
     );
   });
 
@@ -40,8 +59,7 @@ describe("customValidate", () => {
     const errors: any = { renders: {} };
     customValidate(formData, errors);
 
-    expect(errors.renders).toEqual({});
-
+    expect(errors.renders).toEqual({}); // No errors for valid JSON
   });
 
   it("should return an error for invalid JSON in the 'renders' field", () => {

--- a/__tests__/utils/FormValidation.test.ts
+++ b/__tests__/utils/FormValidation.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from "vitest";
+import { customValidate } from "@/utils/formValidation";
+
+describe("customValidate", () => {
+  it("should validate a correct RFC 3339 datetime format", () => {
+    const formData = {
+      temporal_extent: {
+        startdate: "2025-02-03T00:00:00.000Z",
+        enddate: "2025-02-03T23:59:59.999Z",
+      },
+    };
+    const errors: any = { temporal_extent: {} };
+    customValidate(formData, errors);
+
+    expect(errors.temporal_extent.startdate).toBeUndefined();
+    expect(errors.temporal_extent.enddate).toBeUndefined();
+  });
+
+  it("should return an error for invalid RFC 3339 datetime format", () => {
+    const formData = {
+      temporal_extent: {
+        startdate: "2025-02-03 00:00:00",
+        enddate: "2025-02-03 23:59:59",
+      },
+    };
+    const errors: any = { temporal_extent: { startdate: { addError: vi.fn() }, enddate: { addError: vi.fn() } } };
+
+    customValidate(formData, errors);
+
+    expect(errors.temporal_extent.startdate.addError).toHaveBeenCalledWith(
+      "Start Date must be in RFC 3339 format (YYYY-MM-DDTHH:mm:ss.sssZ)"
+    );
+    expect(errors.temporal_extent.enddate.addError).toHaveBeenCalledWith(
+      "End Date must be in RFC 3339 format (YYYY-MM-DDTHH:mm:ss.sssZ)"
+    );
+  });
+
+  it("should validate correct JSON in the 'renders' field", () => {
+    const formData = { renders: '{"key": "value"}' };
+    const errors: any = { renders: {} };
+    customValidate(formData, errors);
+
+    expect(errors.renders).toEqual({});
+
+  });
+
+  it("should return an error for invalid JSON in the 'renders' field", () => {
+    const formData = { renders: '{invalid json}' };
+    const errors: any = { renders: { addError: vi.fn() } };
+
+    customValidate(formData, errors);
+
+    expect(errors.renders.addError).toHaveBeenCalledWith("Invalid JSON format. Please enter a valid JSON object.");
+  });
+});

--- a/components/IngestCreationForm.tsx
+++ b/components/IngestCreationForm.tsx
@@ -60,6 +60,7 @@ function IngestCreationForm({
       formData={formData}
       setFormData={setFormData}
       onSubmit={onFormDataSubmit}
+      defaultTemporalExtent={true}
     />
   );
 }

--- a/components/IngestForm.tsx
+++ b/components/IngestForm.tsx
@@ -10,8 +10,9 @@ import { JSONSchema7 } from 'json-schema';
 
 import ObjectFieldTemplate from '@/utils/ObjectFieldTemplate';
 import jsonSchema from '@/FormSchemas/jsonschema.json';
-import { RJSFSchema, UiSchema } from '@rjsf/utils';
-import { customValidate } from '@/utils/formValidation';
+import { UiSchema } from '@rjsf/utils';
+import { customValidate } from '@/utils/FormValidation';
+import { handleSubmit } from "@/utils/FormHandlers";
 
 const Form = withTheme(AntDTheme);
 
@@ -82,13 +83,6 @@ function IngestForm({
     setFormData((updatedData ?? {}) as Record<string, unknown>);
   };
 
-  const handleSubmit = (data: IChangeEvent<any, RJSFSchema, any>) => {
-    if (onSubmit) {
-      onSubmit(data.formData as Record<string, unknown>);
-    }
-  };
-  
-
   return (
     <Form
       schema={jsonSchema as JSONSchema7}
@@ -100,7 +94,7 @@ function IngestForm({
       }}
       formData={formData}
       onChange={onFormDataChanged}
-      onSubmit={handleSubmit}
+      onSubmit={(data) => handleSubmit(data, onSubmit)}
       formContext={{ updateFormData }}
     >
       {children}

--- a/components/IngestForm.tsx
+++ b/components/IngestForm.tsx
@@ -46,13 +46,22 @@ function IngestForm({
   useEffect(() => {
     if (defaultTemporalExtent) {
       setFormData((prevFormData: FormData | undefined) => {
-        const nowUtc = new Date().toISOString();
+        const now = new Date();
+      
+        // Start of the current UTC day
+        const startOfDay = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), 0, 0, 0))
+          .toISOString();
+        
+        // End of the current UTC day
+        const endOfDay = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), 23, 59, 59))
+          .toISOString();
   
+        console.log('startOfDay', startOfDay)
         return {
           ...prevFormData,
           temporal_extent: {
-            startdate: prevFormData?.temporal_extent?.startdate || nowUtc,
-            enddate: prevFormData?.temporal_extent?.enddate || nowUtc,
+            startdate: prevFormData?.temporal_extent?.startdate || startOfDay,
+            enddate: prevFormData?.temporal_extent?.enddate || endOfDay,
           },
         };
       });

--- a/components/IngestForm.tsx
+++ b/components/IngestForm.tsx
@@ -2,7 +2,7 @@
 
 import { SetStateAction, useEffect } from 'react';
 
-import { IChangeEvent, withTheme } from '@rjsf/core';
+import { withTheme } from '@rjsf/core';
 import { Theme as AntDTheme } from '@rjsf/antd';
 
 import validator from '@rjsf/validator-ajv8';

--- a/components/IngestForm.tsx
+++ b/components/IngestForm.tsx
@@ -11,6 +11,7 @@ import { JSONSchema7 } from 'json-schema';
 import ObjectFieldTemplate from '@/utils/ObjectFieldTemplate';
 import jsonSchema from '@/FormSchemas/jsonschema.json';
 import { RJSFSchema, UiSchema } from '@rjsf/utils';
+import { customValidate } from '@/utils/formValidation';
 
 const Form = withTheme(AntDTheme);
 
@@ -93,25 +94,7 @@ function IngestForm({
       schema={jsonSchema as JSONSchema7}
       uiSchema={uiSchema}
       validator={validator}
-      customValidate={(formData, errors) => {
-        try {
-            // Allow empty field without validation errors
-            if (!formData.renders) {
-                return errors;
-            }
-    
-            const parsed = JSON.parse(formData.renders);
-    
-            // Ensure it's a JSON object (not a string, number, array, etc.)
-            if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-                errors.renders?.addError("Input must be a valid JSON object.");
-            }
-        } catch {
-            errors.renders?.addError("Invalid JSON format. Please enter a valid JSON object.");
-        }
-        return errors;
-    }}
-    
+      customValidate={customValidate}
       templates={{
         ObjectFieldTemplate: ObjectFieldTemplate,
       }}

--- a/components/IngestForm.tsx
+++ b/components/IngestForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { SetStateAction } from 'react';
+import { SetStateAction, useEffect } from 'react';
 
 import { IChangeEvent, withTheme } from '@rjsf/core';
 import { Theme as AntDTheme } from '@rjsf/antd';
@@ -14,6 +14,15 @@ import { RJSFSchema, UiSchema } from '@rjsf/utils';
 
 const Form = withTheme(AntDTheme);
 
+interface TemporalExtent {
+  startdate?: string;
+  enddate?: string;
+}
+
+interface FormData {
+  temporal_extent?: TemporalExtent;
+}
+
 interface FormProps {
   formData: Record<string, unknown> | undefined;
   setFormData: React.Dispatch<React.SetStateAction<Record<string, unknown>>>;
@@ -21,6 +30,7 @@ interface FormProps {
   onSubmit: (formData: Record<string, unknown> | undefined) => void;
   setDisabled?: (disabled: boolean) => void;
   children?: React.ReactNode;
+  defaultTemporalExtent?: boolean;
 }
 
 function IngestForm({
@@ -30,7 +40,24 @@ function IngestForm({
   onSubmit,
   setDisabled,
   children,
+  defaultTemporalExtent = false,
 }: FormProps) {
+
+  useEffect(() => {
+    if (defaultTemporalExtent) {
+      setFormData((prevFormData: FormData | undefined) => {
+        const nowUtc = new Date().toISOString();
+  
+        return {
+          ...prevFormData,
+          temporal_extent: {
+            startdate: prevFormData?.temporal_extent?.startdate || nowUtc,
+            enddate: prevFormData?.temporal_extent?.enddate || nowUtc,
+          },
+        };
+      });
+    }
+  }, [defaultTemporalExtent, setFormData]);
   
   const onFormDataChanged = (formState: { formData?: object }) => {
     setFormData(formState.formData as Record<string, unknown> ?? {});

--- a/utils/FormHandlers.ts
+++ b/utils/FormHandlers.ts
@@ -1,0 +1,27 @@
+import { IChangeEvent } from "@rjsf/core";
+import { RJSFSchema } from "@rjsf/utils";
+
+export const handleSubmit = (
+  data: IChangeEvent<any, RJSFSchema, any>,
+  onSubmit: (formData: Record<string, unknown>) => void
+) => {
+  if (onSubmit) {
+    const updatedFormData = { ...data.formData };
+
+    if (updatedFormData.temporal_extent) {
+      updatedFormData.temporal_extent = {
+        startdate:
+          updatedFormData.temporal_extent.startdate === "" || updatedFormData.temporal_extent.startdate === undefined
+            ? null
+            : updatedFormData.temporal_extent.startdate,
+        enddate:
+          updatedFormData.temporal_extent.enddate === "" || updatedFormData.temporal_extent.enddate === undefined
+            ? null
+            : updatedFormData.temporal_extent.enddate,
+      };
+    }
+
+    onSubmit(updatedFormData as Record<string, unknown>);
+  }
+};
+

--- a/utils/formValidation.ts
+++ b/utils/formValidation.ts
@@ -10,21 +10,19 @@ export const customValidate = (formData: any, errors: any) => {
       }
     }
 
-    // Allow empty strings for startdate & enddate, but enforce RFC 3339 when filled
+    // Allow `null` or empty strings for `startdate` and `enddate`
     if (formData.temporal_extent) {
-      if (
-        formData.temporal_extent.startdate &&
-        formData.temporal_extent.startdate !== "" &&
-        !rfc3339Regex.test(formData.temporal_extent.startdate)
-      ) {
+      const { startdate, enddate } = formData.temporal_extent;
+
+      if (startdate !== null && startdate !== "" && typeof startdate !== "string") {
+        errors.temporal_extent?.startdate?.addError("Start Date must be a string, null, or in RFC 3339 format.");
+      } else if (typeof startdate === "string" && !rfc3339Regex.test(startdate)) {
         errors.temporal_extent?.startdate?.addError("Start Date must be in RFC 3339 format (YYYY-MM-DDTHH:mm:ss.sssZ) or empty.");
       }
 
-      if (
-        formData.temporal_extent.enddate &&
-        formData.temporal_extent.enddate !== "" &&
-        !rfc3339Regex.test(formData.temporal_extent.enddate)
-      ) {
+      if (enddate !== null && enddate !== "" && typeof enddate !== "string") {
+        errors.temporal_extent?.enddate?.addError("End Date must be a string, null, or in RFC 3339 format.");
+      } else if (typeof enddate === "string" && !rfc3339Regex.test(enddate)) {
         errors.temporal_extent?.enddate?.addError("End Date must be in RFC 3339 format (YYYY-MM-DDTHH:mm:ss.sssZ) or empty.");
       }
     }

--- a/utils/formValidation.ts
+++ b/utils/formValidation.ts
@@ -1,0 +1,27 @@
+export const rfc3339Regex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+export const customValidate = (formData: any, errors: any) => {
+  try {
+    // Validate "renders" JSON format
+    if (formData.renders) {
+      const parsed = JSON.parse(formData.renders);
+      if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+        errors.renders?.addError("Input must be a valid JSON object.");
+      }
+    }
+
+    // Validate Temporal Extent (Startdate & Enddate)
+    if (formData.temporal_extent) {
+      if (formData.temporal_extent.startdate && !rfc3339Regex.test(formData.temporal_extent.startdate)) {
+        errors.temporal_extent?.startdate?.addError("Start Date must be in RFC 3339 format (YYYY-MM-DDTHH:mm:ss.sssZ)");
+      }
+      if (formData.temporal_extent.enddate && !rfc3339Regex.test(formData.temporal_extent.enddate)) {
+        errors.temporal_extent?.enddate?.addError("End Date must be in RFC 3339 format (YYYY-MM-DDTHH:mm:ss.sssZ)");
+      }
+    }
+  } catch {
+    errors.renders?.addError("Invalid JSON format. Please enter a valid JSON object.");
+  }
+
+  return errors;
+};

--- a/utils/formValidation.ts
+++ b/utils/formValidation.ts
@@ -10,13 +10,22 @@ export const customValidate = (formData: any, errors: any) => {
       }
     }
 
-    // Validate Temporal Extent (Startdate & Enddate)
+    // Allow empty strings for startdate & enddate, but enforce RFC 3339 when filled
     if (formData.temporal_extent) {
-      if (formData.temporal_extent.startdate && !rfc3339Regex.test(formData.temporal_extent.startdate)) {
-        errors.temporal_extent?.startdate?.addError("Start Date must be in RFC 3339 format (YYYY-MM-DDTHH:mm:ss.sssZ)");
+      if (
+        formData.temporal_extent.startdate &&
+        formData.temporal_extent.startdate !== "" &&
+        !rfc3339Regex.test(formData.temporal_extent.startdate)
+      ) {
+        errors.temporal_extent?.startdate?.addError("Start Date must be in RFC 3339 format (YYYY-MM-DDTHH:mm:ss.sssZ) or empty.");
       }
-      if (formData.temporal_extent.enddate && !rfc3339Regex.test(formData.temporal_extent.enddate)) {
-        errors.temporal_extent?.enddate?.addError("End Date must be in RFC 3339 format (YYYY-MM-DDTHH:mm:ss.sssZ)");
+
+      if (
+        formData.temporal_extent.enddate &&
+        formData.temporal_extent.enddate !== "" &&
+        !rfc3339Regex.test(formData.temporal_extent.enddate)
+      ) {
+        errors.temporal_extent?.enddate?.addError("End Date must be in RFC 3339 format (YYYY-MM-DDTHH:mm:ss.sssZ) or empty.");
       }
     }
   } catch {


### PR DESCRIPTION
this closes #24 

start date and end date are now string entries. validation allows them to be either a RFC 3339 date time or null.  by default, they are the start end end of the current UTC date.  deleting an entry saves it as `null`
other defaults:

license (CC0-1.0)
spatial extent 
```
{
           "xmin": -180,
           "ymin": -90,
         "xmax": 180,
          "ymax": 90
      }
```

STAC extension 
```
[
        "https://stac-extensions.github.io/render/v1.0.0/schema.json",
       "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
    ]
```

stac_version (1.0.0)
providers
```
 {
        "name": "NASA VEDA",
        "roles": [
            "host"
        ],
        "url": "https://www.earthdata.nasa.gov/dashboard/"
        }
```

thumbnail fields
```
{
                    "name": "NASA VEDA",
                    "roles": [
                        "host"
                    ],
                    "url": "https://www.earthdata.nasa.gov/dashboard/"
                }
```