### PR TITLE
fix: roles within items_assets not displayed do to brackets

### DIFF
--- a/FormSchemas/jsonschema.json
+++ b/FormSchemas/jsonschema.json
@@ -234,15 +234,14 @@
                         },
                         "roles": {
                             "type": "array",
-                            "items": [
+                            "items": 
                                 {
                                     "type": "string"
-                                }
-                            ],
-                            "default": [
-                                "data",
-                                "layer"
-                            ]
+                                },
+                                "default": [
+                                    "data",
+                                    "layer"
+                                ]
                         },
                         "title": {
                             "type": "string",

--- a/FormSchemas/uischema.json
+++ b/FormSchemas/uischema.json
@@ -104,12 +104,12 @@
         "cog_default": {
             "ui:grid": [
                 {
-                    "type": 12,
-                    "roles": 12
+                    "title": 12,
+                    "type": 12
                 },
                 {
-                    "title": 12,
-                    "description": 12
+                    "description": 12,
+                    "roles": 12
                 }
             ]
         }


### PR DESCRIPTION
I had `[` brackets instead of parentheses '{' so RJSF hid the roles options