### PR TITLE
Remove dashboard prefix for time density and is_periodic

### DIFF
--- a/FormSchemas/jsonschema.json
+++ b/FormSchemas/jsonschema.json
@@ -36,11 +36,11 @@
       "title": "STAC Version",
       "default": "1.0.0"
     },
-    "dashboard:is_periodic": {
+    "is_periodic": {
       "type": "boolean",
       "title": "Is Periodic?"
     },
-    "dashboard:time_density": {
+    "time_density": {
       "type": "string",
       "title": "Time Density"
     },

--- a/FormSchemas/uischema.json
+++ b/FormSchemas/uischema.json
@@ -4,8 +4,8 @@
       "collection": 4,
       "title": 6,
       "license": 2,
-      "dashboard:is_periodic": 3,
-      "dashboard:time_density": 3,
+      "is_periodic": 3,
+      "time_density": 3,
       "data_type": 3,
       "stac_version": 3
     },


### PR DESCRIPTION
The dataset configs typically do not include the `dashboard:` prefix.  For example: 
```
{ ...
  "is_periodic": true,
  "time_density": "day",
```
To ensure that the manual json can parse these values, this PR removes the `dashboard: ` prefix from the form.