### PR TITLE
add search option to cog controls select components

### DIFF
--- a/__mocks__/handlers.ts
+++ b/__mocks__/handlers.ts
@@ -58,4 +58,32 @@ export const handlers = [
       center: [0, 0, 2],
     });
   }),
+
+  http.get('/api/raster/colorMaps', ({ request }) => {
+    return HttpResponse.json({
+      colorMaps: ['accent', 'autumn', 'binary', 'bwr', 'cfastie'],
+      links: [
+        {
+          href: 'https://staging.openveda.cloud/api/raster/colorMaps',
+          rel: 'self',
+          type: 'application/json',
+          title: 'List of available colormaps',
+        },
+        {
+          href: 'https://staging.openveda.cloud/api/raster/colorMaps/{colorMapId}',
+          rel: 'data',
+          type: 'application/json',
+          templated: true,
+          title: 'Retrieve colorMap metadata',
+        },
+        {
+          href: 'https://staging.openveda.cloud/api/raster/colorMaps/{colorMapId}?format=png',
+          rel: 'data',
+          type: 'image/png',
+          templated: true,
+          title: 'Retrieve colorMap as image',
+        },
+      ],
+    });
+  }),
 ];

--- a/__tests__/playwright/COGControlsForm.test.tsx
+++ b/__tests__/playwright/COGControlsForm.test.tsx
@@ -104,7 +104,7 @@ test.describe('COGControlsForm', () => {
     // Open the dropdown and select "Band 2"
     await colormapDropdown.click();
     const colormapOption = page.locator('.ant-select-item', {
-      hasText: 'CFastie',
+      hasText: 'cfastie',
     });
     await colormapOption.click();
 

--- a/components/COGControlsForm.tsx
+++ b/components/COGControlsForm.tsx
@@ -181,7 +181,11 @@ const COGControlsForm: React.FC<COGControlsFormProps> = ({
       <Row gutter={16}>
         <Col span={12}>
           <Form.Item label="Colormap" name="selectedColormap">
-            <Select onChange={onColormapChange} data-testid="colormap">
+            <Select
+              showSearch
+              onChange={onColormapChange}
+              data-testid="colormap"
+            >
               {colorMapsList.map((colorMap) => (
                 <Option key={colorMap} value={colorMap}>
                   {colorMap}
@@ -203,7 +207,11 @@ const COGControlsForm: React.FC<COGControlsFormProps> = ({
       <Row gutter={16}>
         <Col span={12}>
           <Form.Item label="Resampling" name="selectedResampling">
-            <Select data-testid="resampling" onChange={onResamplingChange}>
+            <Select
+              showSearch
+              data-testid="resampling"
+              onChange={onResamplingChange}
+            >
               <Option value="nearest">Nearest</Option>
               <Option value="bilinear">Bilinear</Option>
               <Option value="cubic">Cubic</Option>


### PR DESCRIPTION
With so many colormap options, it seems easier to allow a user to search as well as scroll through the dropdown options.
<img width="714" alt="Screenshot 2025-02-13 at 9 51 58 AM" src="https://github.com/user-attachments/assets/737d877f-fd82-4970-bc24-748c07872e1c" />
