### PR TITLE
work around for ant design RJSF handling of messages

### DIFF
--- a/__tests__/playwright/COGViewerDrawer.test.tsx
+++ b/__tests__/playwright/COGViewerDrawer.test.tsx
@@ -331,4 +331,52 @@ test.describe('COG Viewer Drawer', () => {
       );
     });
   });
+
+  test('COG Viewer does not open if sample files input is empty', async ({
+    page,
+  }, testInfo) => {
+    await test.step('navigate to create ingest page', async () => {
+      await page.goto('/create-ingest');
+    });
+
+    await test.step('do not enter URL of Sample File but enter valid json in renders object', async () => {
+      await page.getByLabel('dashboard').fill(
+        JSON.stringify(
+          {
+            resampling: 'nearest',
+            bidx: [1],
+            colormap_name: 'rdbu',
+            assets: ['cog_default'],
+            rescale: [[-1, 1]],
+            color_formula: 'test123',
+            nodata: 255,
+            title: 'VEDA Dashboard Render Parameters',
+          },
+          null,
+          2
+        )
+      );
+    });
+    await test.step('click button to open COG Viewer Drawer', async () => {
+      await page
+        .getByRole('button', {
+          name: /Generate Renders Object from Sample File/i,
+        })
+        .click();
+    });
+    await expect(
+      page.getByText(/Sample File URL is required/i),
+      'verify error message appears'
+    ).toBeVisible();
+    await expect(
+      page.locator('.ant-drawer').filter({ hasText: /COG Rendering Options/i }),
+      'COG Viewer Drawer remains hidden'
+    ).toBeHidden();
+
+    const errorScreenshot = await page.screenshot();
+    testInfo.attach('error message if no sample file url present', {
+      body: errorScreenshot,
+      contentType: 'image/png',
+    });
+  });
 });

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,8 @@
+import '@ant-design/v5-patch-for-react-19';
 import './globals.css';
 import React from 'react';
 import { Inter } from 'next/font/google';
 import { AntdRegistry } from '@ant-design/nextjs-registry';
-import '@ant-design/v5-patch-for-react-19';
 import 'leaflet/dist/leaflet.css';
 
 const inter = Inter({ subsets: ['latin'] });

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+import '@ant-design/v5-patch-for-react-19';
 
 import { Space } from 'antd';
 import { Amplify } from 'aws-amplify';

--- a/components/IngestForm.tsx
+++ b/components/IngestForm.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import '@ant-design/v5-patch-for-react-19';
+
 import { SetStateAction, useEffect, useState } from 'react';
 import { Tabs } from 'antd';
 import { withTheme } from '@rjsf/core';

--- a/utils/ObjectFieldTemplate.tsx
+++ b/utils/ObjectFieldTemplate.tsx
@@ -1,4 +1,7 @@
-import React, { useState } from 'react';
+'use client'; // Ensure this component is client-side only
+
+import '@ant-design/v5-patch-for-react-19';
+import React, { useEffect, useState } from 'react';
 import classNames from 'classnames';
 import isObject from 'lodash/isObject';
 import isNumber from 'lodash/isNumber';
@@ -24,11 +27,10 @@ import {
   ConfigConsumerProps,
 } from 'antd/lib/config-provider/context';
 import Button from 'antd/lib/button';
-import message from 'antd/lib/message';
 import { ImportOutlined } from '@ant-design/icons';
-import '@ant-design/v5-patch-for-react-19';
 
 import COGDrawerViewer from '@/components/COGDrawerViewer';
+import { Alert, Tooltip } from 'antd';
 
 const DESCRIPTION_COL_STYLE = {
   paddingBottom: '8px',
@@ -54,6 +56,13 @@ export default function ObjectFieldTemplate<
     title,
     uiSchema,
   } = props;
+
+  const typedFormData = formData as Record<string, any>;
+  const [errorMessage, setErrorMessage] = useState('');
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [drawerUrl, setDrawerUrl] = useState<string | null>(null);
+  const [renders, setRenders] = useState<string | null>(null);
+  const [, forceUpdate] = useState(0);
 
   const uiOptions = getUiOptions<T, S, F>(uiSchema);
   const TitleFieldTemplate = getTemplate<'TitleFieldTemplate', T, S, F>(
@@ -125,28 +134,28 @@ export default function ObjectFieldTemplate<
     return defaultColSpan;
   };
 
-  const typedFormData = formData as Record<string, any>;
-
-  const [drawerOpen, setdrawerOpen] = useState(false);
-  const [drawerUrl, setDrawerUrl] = useState<string | null>(null);
-  const [renders, setRenders] = useState<string | null>(null);
-
   const handleOpenDrawer = () => {
     const sampleUrl = typedFormData?.sample_files?.[0];
     const rendersDashboardEntry = typedFormData?.renders?.dashboard;
-    if (sampleUrl) {
-      setDrawerUrl(sampleUrl);
-      setdrawerOpen(true);
-    } else {
-      console.error('A sample URL is required to open the viewer.');
+
+    if (!sampleUrl) {
+      setErrorMessage('Sample File URL is required');
+      forceUpdate((prev) => prev + 1); // Force re-render
+      return;
     }
+
+    setErrorMessage('');
+    setDrawerUrl(sampleUrl);
+    setDrawerOpen(true);
+
     if (rendersDashboardEntry) {
       setRenders(rendersDashboardEntry);
     }
+    forceUpdate((prev) => prev + 1);
   };
 
   const handleCloseDrawer = () => {
-    setdrawerOpen(false);
+    setDrawerOpen(false);
   };
 
   const handleAcceptRenderOptions = (renderOptions: string) => {
@@ -221,6 +230,18 @@ export default function ObjectFieldTemplate<
                                     gap: '10px',
                                   }}
                                 >
+                                  {/* 🚀 Make sure the alert shows up */}
+                                  {errorMessage && (
+                                    <div key={errorMessage}>
+                                      {' '}
+                                      {/* 🔥 KEY ensures DOM updates */}
+                                      <Alert
+                                        message={errorMessage}
+                                        type="error"
+                                        showIcon
+                                      />
+                                    </div>
+                                  )}
                                   <Button
                                     type="primary"
                                     onClick={handleOpenDrawer}


### PR DESCRIPTION
If a user attempts to click the "Generate Renders Options" button without entering a sample url, the ant-d error message component was not appearing.  It appears that there is a mix of issues between ant-d, the RJSFF form, and the React 19's rendering.  

the https://ant.design/docs/react/v5-for-19 workaround had been applied and fixed things elsewhere, but when the RJSF form was loading the components and trying to cause a re-render, the error still occurred.

the alert Text seems to work as long as it is wrapped in a div with a key that changes and forces the RJSF form to update, thus skipping the nested alert component's attempt at forcing the update

