### PR TITLE
revert removal of dashboard prefix

### DIFF
--- a/FormSchemas/jsonschema.json
+++ b/FormSchemas/jsonschema.json
@@ -36,11 +36,11 @@
       "title": "STAC Version",
       "default": "1.0.0"
     },
-    "is_periodic": {
+    "dashboard:is_periodic": {
       "type": "boolean",
       "title": "Is Periodic?"
     },
-    "time_density": {
+    "dashboard:time_density": {
       "type": "string",
       "title": "Time Density"
     },

--- a/FormSchemas/uischema.json
+++ b/FormSchemas/uischema.json
@@ -4,8 +4,8 @@
       "collection": 4,
       "title": 6,
       "license": 2,
-      "is_periodic": 3,
-      "time_density": 3,
+      "dashboard:is_periodic": 3,
+      "dashboard:time_density": 3,
       "data_type": 3,
       "stac_version": 3
     },


### PR DESCRIPTION
@anayeaye - this returns the "dashboard:" prefix to `is_periodic` and `time_density` as requested by @anayeaye 

cc: @smohiudd 