### PR TITLE
allow unauthenticated api calls if NEXT_PUBLIC_DISABLE_AUTH=true

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -25,7 +25,7 @@ export async function middleware(request: NextRequest) {
   });
 
   // If user is authenticated then the route request will continue on
-  if (authenticated) {
+  if (process.env.NEXT_PUBLIC_DISABLE_AUTH || authenticated) {
     return response;
   }
 


### PR DESCRIPTION
in testing locally with `NEXT_PUBLIC_DISABLE_AUTH=true`, @slesaad discovered that the protected routes still returned a `401` if not authenticated.  This short circuits the middleware auth check if that env variable is true.