### PR TITLE
Update Json Validation error messages for additional fields

### DIFF
--- a/__tests__/playwright/CreateIngestPage.test.tsx
+++ b/__tests__/playwright/CreateIngestPage.test.tsx
@@ -277,7 +277,7 @@ test.describe('Create Ingest Page', () => {
       await expect(
         page
           .getByRole('listitem')
-          .filter({ hasText: 'must NOT have additional properties' }),
+          .filter({ hasText: 'validJSON is not defined in schema' }),
         'additional property in JSON should create error'
       ).toBeVisible();
     });

--- a/components/JSONEditor.tsx
+++ b/components/JSONEditor.tsx
@@ -138,8 +138,10 @@ const JSONEditor: React.FC<JSONEditorProps> = ({
       const isValid = validateSchema(parsedValue);
       if (!isValid) {
         setSchemaErrors(
-          validateSchema.errors?.map(
-            (err) => `${err.instancePath} ${err.message}`
+          validateSchema.errors?.map((err) =>
+            err.message === 'must NOT have additional properties'
+              ? `${err.params.additionalProperty} is not defined in schema`
+              : `${err.instancePath} ${err.message}`
           ) || []
         );
         return;


### PR DESCRIPTION
This is just a small tweak to give a clearer error message when validation fails due to extra fields in the pasted json schema to allow users to know what field was unexpected.

<img width="45%" alt="original errors message" src="https://github.com/user-attachments/assets/e0e227e0-c643-4f47-9b05-d3cdbf37b367" />

<img width="50%" alt="updated errors message" src="https://github.com/user-attachments/assets/3c493c2d-8bf0-424d-8973-24c297d554e6" />

