### PR TITLE
make renders dashboard object required and update tests

### DIFF
--- a/FormSchemas/jsonschema.json
+++ b/FormSchemas/jsonschema.json
@@ -11,7 +11,8 @@
     "sample_files",
     "data_type",
     "providers",
-    "item_assets"
+    "item_assets",
+    "renders"
   ],
   "properties": {
     "collection": {
@@ -249,6 +250,7 @@
     "renders": {
       "title": "Renders",
       "type": "object",
+      "required": ["dashboard"],
       "properties": {
         "dashboard": {
           "type": "string",

--- a/__mocks__/retrieveIngestResponse.ts
+++ b/__mocks__/retrieveIngestResponse.ts
@@ -54,5 +54,10 @@ export const retrieveIngestResponse = {
     title: 'test',
     license: 'test',
     description: 'seeded ingest description #1',
+    renders: {
+      dashboard: {
+        json: true,
+      },
+    },
   },
 };

--- a/__tests__/components/JSONEditor.test.tsx
+++ b/__tests__/components/JSONEditor.test.tsx
@@ -74,6 +74,11 @@ const mockFormData = {
   collection: 'test-collection',
   title: 'test',
   description: 'test',
+  renders: {
+    dashboard: {
+      json: true,
+    },
+  },
 };
 
 describe('JSONEditor', () => {

--- a/__tests__/playwright/EditIngestPage.test.tsx
+++ b/__tests__/playwright/EditIngestPage.test.tsx
@@ -54,6 +54,11 @@ const modifiedConfig = {
       roles: ['thumbnail'],
     },
   },
+  renders: {
+    dashboard: {
+      json: true,
+    },
+  },
 };
 
 test.describe('Edit Ingest Page', () => {
@@ -122,10 +127,23 @@ test.describe('Edit Ingest Page', () => {
           'formData'
         );
 
+        // make sure the dashboard object is a prettified string before asserting
+        const expectedModifiedConfig = {
+          ...modifiedConfig,
+          renders: {
+            ...modifiedConfig.renders,
+            dashboard: JSON.stringify(
+              modifiedConfig.renders.dashboard,
+              null,
+              2
+            ),
+          },
+        };
+
         expect(
           postData.formData,
           'validate formData matches modified json'
-        ).toEqual(expect.objectContaining(modifiedConfig));
+        ).toMatchObject(expectedModifiedConfig);
 
         // Block the request
         await route.abort();


### PR DESCRIPTION
This closes #57 

Dashboard object in renders will now be required.  Mocks in tests were updated with that new requirement.