### PR TITLE
get upload image signed url to display it

### DIFF
--- a/__mocks__/handlers.ts
+++ b/__mocks__/handlers.ts
@@ -110,4 +110,11 @@ export const handlers = [
       return HttpResponse.json({ status: 200 });
     }
   ),
+
+  http.post('/api/get-signed-url', async ({ request }) => {
+    return HttpResponse.json({
+      signedUrl:
+        'https://bucket.s3.us-west-2.amazonaws.com/thumbnail.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=ASIARVKJBJKAQFGENG5C%2F20250404%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20250404T172309Z&X-Amz-Expires=900&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEKL%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCXVzLXdlc3QtMiJHMEUCIQDbCay0UenLbnMIC%2FNEBrzwxs9OxA%2FpiInjFciy4QbeCwIgXp6TynvBQ8%2BUYk4DTvMDM9BZ7rfOmKt9eVCtglRatyAqqQIIGxACGgwxMTQ1MDY2ODA5NjEiDCOsgOx%2BRrGpNQnmWSqGAprgmAbuZhPuNq%2B9syAbMquhq0NKrkxLh0KacxVX3dAX%2FP1gTsCWyQKj1YFTw6owUw0OVMUpFCRjYQDF0GxpwkDqAVYoRzHX%2BLjgtEyvf1BrpDlORgXlN4GwTaohj15%2B8mrtLY3vfW6UEDWDb74rZrv%2FfScK6vofbCd%2BDUg1GtSoGWBpfMVlbYUxOFR5UWnUGyCdNpe7kjJMynMpC%2FlfFlqbI8qdV0LFECOX7S4e52aJVutlcHqVrPwAL7eNYRBk9dYLQH3Mz8nOSHGplOHQuaIZe4YRS0goOrg2WEU8kOXizeVueH9RSB91fwSkeGtHsV8t2fhBsGES4rhaEyFUvgUzD3DHO94w%2FarAvwY6nQG8InOBWfZXbitDPLbnkerLLWfRynjhGZCPaP5VI5D4yRjZcxEaBqvOyRtlLQSG5udSRf7ipKl%2Fgl0AoQPX5wen3A7bHMdpOAzpkn5YIIvYlLIG5SiZDsYopVPtFERiq1mX1xuPmHW58LX%2FPuWsFgKqaSZnTtwsu9cst3PBaHrF9Kdoz%2BoO%2BM%2FFJXvKttr3sJ8Wkexl6bbNRVtSITym&X-Amz-Signature=42e140a71802dcc427a4b76dc217b849066753dfb415d29e29f47a5d36f9008a&X-Amz-SignedHeaders=host',
+    });
+  }),
 ];

--- a/__tests__/playwright/ThumbnailUploader.test.tsx
+++ b/__tests__/playwright/ThumbnailUploader.test.tsx
@@ -114,7 +114,6 @@ test.describe('Thumbnail Uploader Page', () => {
     await page.route(mockSignedURL, async (route) => {
       console.log(`Image request intercepted: ${route.request().url()}`);
 
-      // Respond with a small 1x1 transparent PNG
       const imageBuffer = Buffer.from(imageBase64, 'base64');
 
       await route.fulfill({

--- a/__tests__/playwright/ThumbnailUploader.test.tsx
+++ b/__tests__/playwright/ThumbnailUploader.test.tsx
@@ -3,24 +3,24 @@ import { HttpResponse } from 'msw';
 import path from 'path';
 import { imageBase64 } from '@/__mocks__/images/greenCheckImageBase64';
 
+const mockSignedURL =
+  'https://bucket.s3.us-west-2.amazonaws.com/thumbnail.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=ASIARVKJBJKAQFGENG5C%2F20250404%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20250404T172309Z&X-Amz-Expires=900&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEKL%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCXVzLXdlc3QtMiJHMEUCIQDbCay0UenLbnMIC%2FNEBrzwxs9OxA%2FpiInjFciy4QbeCwIgXp6TynvBQ8%2BUYk4DTvMDM9BZ7rfOmKt9eVCtglRatyAqqQIIGxACGgwxMTQ1MDY2ODA5NjEiDCOsgOx%2BRrGpNQnmWSqGAprgmAbuZhPuNq%2B9syAbMquhq0NKrkxLh0KacxVX3dAX%2FP1gTsCWyQKj1YFTw6owUw0OVMUpFCRjYQDF0GxpwkDqAVYoRzHX%2BLjgtEyvf1BrpDlORgXlN4GwTaohj15%2B8mrtLY3vfW6UEDWDb74rZrv%2FfScK6vofbCd%2BDUg1GtSoGWBpfMVlbYUxOFR5UWnUGyCdNpe7kjJMynMpC%2FlfFlqbI8qdV0LFECOX7S4e52aJVutlcHqVrPwAL7eNYRBk9dYLQH3Mz8nOSHGplOHQuaIZe4YRS0goOrg2WEU8kOXizeVueH9RSB91fwSkeGtHsV8t2fhBsGES4rhaEyFUvgUzD3DHO94w%2FarAvwY6nQG8InOBWfZXbitDPLbnkerLLWfRynjhGZCPaP5VI5D4yRjZcxEaBqvOyRtlLQSG5udSRf7ipKl%2Fgl0AoQPX5wen3A7bHMdpOAzpkn5YIIvYlLIG5SiZDsYopVPtFERiq1mX1xuPmHW58LX%2FPuWsFgKqaSZnTtwsu9cst3PBaHrF9Kdoz%2BoO%2BM%2FFJXvKttr3sJ8Wkexl6bbNRVtSITym&X-Amz-Signature=42e140a71802dcc427a4b76dc217b849066753dfb415d29e29f47a5d36f9008a&X-Amz-SignedHeaders=host';
+
 test.describe('Thumbnail Uploader Page', () => {
   test('Upload unique image with proper dimensions', async ({
     page,
   }, testInfo) => {
-    await page.route(
-      'https://s3bucket.s3.us-west-2.amazonaws.com/thumbnail.jpg',
-      async (route) => {
-        console.log(`Image request intercepted: ${route.request().url()}`);
+    await page.route(mockSignedURL, async (route) => {
+      console.log(`Image request intercepted: ${route.request().url()}`);
 
-        const imageBuffer = Buffer.from(imageBase64, 'base64');
+      const imageBuffer = Buffer.from(imageBase64, 'base64');
 
-        await route.fulfill({
-          status: 200,
-          contentType: 'image/jpg',
-          body: imageBuffer,
-        });
-      }
-    );
+      await route.fulfill({
+        status: 200,
+        contentType: 'image/jpg',
+        body: imageBuffer,
+      });
+    });
 
     //
     await test.step('Navigate to the Thumbnail Upload Page', async () => {
@@ -111,21 +111,18 @@ test.describe('Thumbnail Uploader Page', () => {
       })
     );
 
-    await page.route(
-      'https://s3bucket.s3.us-west-2.amazonaws.com/thumbnail.jpg',
-      async (route) => {
-        console.log(`Image request intercepted: ${route.request().url()}`);
+    await page.route(mockSignedURL, async (route) => {
+      console.log(`Image request intercepted: ${route.request().url()}`);
 
-        // Respond with a small 1x1 transparent PNG
-        const imageBuffer = Buffer.from(imageBase64, 'base64');
+      // Respond with a small 1x1 transparent PNG
+      const imageBuffer = Buffer.from(imageBase64, 'base64');
 
-        await route.fulfill({
-          status: 200,
-          contentType: 'image/jpg',
-          body: imageBuffer,
-        });
-      }
-    );
+      await route.fulfill({
+        status: 200,
+        contentType: 'image/jpg',
+        body: imageBuffer,
+      });
+    });
 
     await test.step('Navigate to the Thumbnail Upload Page', async () => {
       await page.goto('/upload');
@@ -212,20 +209,17 @@ test.describe('Thumbnail Uploader Page', () => {
   test('Size Validation prevents image upload with wrong dimensions', async ({
     page,
   }, testInfo) => {
-    await page.route(
-      'https://s3bucket.s3.us-west-2.amazonaws.com/thumbnail.jpg',
-      async (route) => {
-        console.log(`Image request intercepted: ${route.request().url()}`);
+    await page.route(mockSignedURL, async (route) => {
+      console.log(`Image request intercepted: ${route.request().url()}`);
 
-        const imageBuffer = Buffer.from(imageBase64, 'base64');
+      const imageBuffer = Buffer.from(imageBase64, 'base64');
 
-        await route.fulfill({
-          status: 200,
-          contentType: 'image/jpg',
-          body: imageBuffer,
-        });
-      }
-    );
+      await route.fulfill({
+        status: 200,
+        contentType: 'image/jpg',
+        body: imageBuffer,
+      });
+    });
 
     await test.step('Navigate to the Thumbnail Upload Page', async () => {
       await page.goto('/upload');

--- a/__tests__/playwright/ThumbnailUploader.test.tsx
+++ b/__tests__/playwright/ThumbnailUploader.test.tsx
@@ -27,14 +27,6 @@ test.describe('Thumbnail Uploader Page', () => {
       await page.goto('/upload');
     });
 
-    // watch for img src request
-    const responsePromise = page.waitForResponse(
-      (res) =>
-        res
-          .url()
-          .includes('s3bucket.s3.us-west-2.amazonaws.com/thumbnail.jpg') &&
-        res.status() === 200
-    );
     await test.step('click to upload a file', async () => {
       const [fileChooser] = await Promise.all([
         page.waitForEvent('filechooser'),
@@ -96,8 +88,6 @@ test.describe('Thumbnail Uploader Page', () => {
       'Uploaded Thumbnail heading'
     ).toBeVisible();
 
-    await responsePromise;
-
     const thumbnailUploadScreenshot = await page.screenshot({ fullPage: true });
     testInfo.attach('Succesfull Image upload', {
       body: thumbnailUploadScreenshot,
@@ -141,14 +131,6 @@ test.describe('Thumbnail Uploader Page', () => {
       await page.goto('/upload');
     });
 
-    // watch for img src request
-    const responsePromise = page.waitForResponse(
-      (res) =>
-        res
-          .url()
-          .includes('s3bucket.s3.us-west-2.amazonaws.com/thumbnail.jpg') &&
-        res.status() === 200
-    );
     await test.step('click to upload a file', async () => {
       const [fileChooser] = await Promise.all([
         page.waitForEvent('filechooser'),
@@ -225,8 +207,6 @@ test.describe('Thumbnail Uploader Page', () => {
       page.getByAltText(/uploaded thumbnail/i),
       'Uploaded Thumbnail heading'
     ).toBeVisible();
-
-    await responsePromise;
   });
 
   test('Size Validation prevents image upload with wrong dimensions', async ({

--- a/__tests__/playwright/ThumbnailUploaderDrawer.test.tsx
+++ b/__tests__/playwright/ThumbnailUploaderDrawer.test.tsx
@@ -13,7 +13,7 @@ test.describe('Thumbnail Uploader Drawer', () => {
     );
 
     await page.route(
-      'https://s3bucket.s3.us-west-2.amazonaws.com/thumbnail.jpg',
+      'https://bucket.s3.us-west-2.amazonaws.com/thumbnail.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=ASIARVKJBJKAQFGENG5C%2F20250404%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20250404T172309Z&X-Amz-Expires=900&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEKL%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCXVzLXdlc3QtMiJHMEUCIQDbCay0UenLbnMIC%2FNEBrzwxs9OxA%2FpiInjFciy4QbeCwIgXp6TynvBQ8%2BUYk4DTvMDM9BZ7rfOmKt9eVCtglRatyAqqQIIGxACGgwxMTQ1MDY2ODA5NjEiDCOsgOx%2BRrGpNQnmWSqGAprgmAbuZhPuNq%2B9syAbMquhq0NKrkxLh0KacxVX3dAX%2FP1gTsCWyQKj1YFTw6owUw0OVMUpFCRjYQDF0GxpwkDqAVYoRzHX%2BLjgtEyvf1BrpDlORgXlN4GwTaohj15%2B8mrtLY3vfW6UEDWDb74rZrv%2FfScK6vofbCd%2BDUg1GtSoGWBpfMVlbYUxOFR5UWnUGyCdNpe7kjJMynMpC%2FlfFlqbI8qdV0LFECOX7S4e52aJVutlcHqVrPwAL7eNYRBk9dYLQH3Mz8nOSHGplOHQuaIZe4YRS0goOrg2WEU8kOXizeVueH9RSB91fwSkeGtHsV8t2fhBsGES4rhaEyFUvgUzD3DHO94w%2FarAvwY6nQG8InOBWfZXbitDPLbnkerLLWfRynjhGZCPaP5VI5D4yRjZcxEaBqvOyRtlLQSG5udSRf7ipKl%2Fgl0AoQPX5wen3A7bHMdpOAzpkn5YIIvYlLIG5SiZDsYopVPtFERiq1mX1xuPmHW58LX%2FPuWsFgKqaSZnTtwsu9cst3PBaHrF9Kdoz%2BoO%2BM%2FFJXvKttr3sJ8Wkexl6bbNRVtSITym&X-Amz-Signature=42e140a71802dcc427a4b76dc217b849066753dfb415d29e29f47a5d36f9008a&X-Amz-SignedHeaders=host',
       async (route) => {
         console.log(`Image request intercepted: ${route.request().url()}`);
 
@@ -31,6 +31,13 @@ test.describe('Thumbnail Uploader Drawer', () => {
     await test.step('Navigate to the Ingest Creation Page', async () => {
       await page.goto('/create-ingest');
     });
+
+    // watch for img src request
+    const responsePromise = page.waitForResponse(
+      (res) =>
+        res.url().includes('s3.us-west-2.amazonaws.com/thumbnail.jpg') &&
+        res.status() === 200
+    );
 
     await test.step('enter text in Collection Input to validate later that it is not overwritten', async () => {
       await page
@@ -106,7 +113,7 @@ test.describe('Thumbnail Uploader Drawer', () => {
       'Uploaded Thumbnail heading'
     ).toBeVisible();
 
-    const thumbnailUploadScreenshot = await page.screenshot();
+    const thumbnailUploadScreenshot = await page.screenshot({ fullPage: true });
     testInfo.attach('Successful Image upload', {
       body: thumbnailUploadScreenshot,
       contentType: 'image/png',

--- a/__tests__/playwright/ThumbnailUploaderDrawer.test.tsx
+++ b/__tests__/playwright/ThumbnailUploaderDrawer.test.tsx
@@ -32,15 +32,6 @@ test.describe('Thumbnail Uploader Drawer', () => {
       await page.goto('/create-ingest');
     });
 
-    // watch for img src request
-    const responsePromise = page.waitForResponse(
-      (res) =>
-        res
-          .url()
-          .includes('s3bucket.s3.us-west-2.amazonaws.com/thumbnail.jpg') &&
-        res.status() === 200
-    );
-
     await test.step('enter text in Collection Input to validate later that it is not overwritten', async () => {
       await page
         .getByRole('textbox', { name: /collection/i })
@@ -114,8 +105,6 @@ test.describe('Thumbnail Uploader Drawer', () => {
       page.getByAltText(/uploaded thumbnail/i),
       'Uploaded Thumbnail heading'
     ).toBeVisible();
-
-    await responsePromise;
 
     const thumbnailUploadScreenshot = await page.screenshot();
     testInfo.attach('Successful Image upload', {

--- a/app/api/get-signed-url/route.ts
+++ b/app/api/get-signed-url/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSignedUrlForGetObject } from '@/utils/s3';
+
+export async function POST(req: NextRequest) {
+  try {
+    const { url } = await req.json();
+
+    if (!url) {
+      return NextResponse.json({ error: 'Missing S3 URL' }, { status: 400 });
+    }
+
+    const parsedUrl = new URL(url);
+    const key = parsedUrl.pathname.substring(1);
+
+    if (!key) {
+      return NextResponse.json(
+        { error: 'Could not extract object key from URL' },
+        { status: 400 }
+      );
+    }
+
+    let signedUrl: string | undefined;
+    try {
+      signedUrl = await getSignedUrlForGetObject(key);
+      if (!signedUrl) {
+        return NextResponse.json(
+          { error: 'Failed to generate signed URL for GET' },
+          { status: 500 }
+        );
+      }
+    } catch (error) {
+      console.error('Error generating signed URL for GET:', error);
+      return NextResponse.json(
+        { error: 'Failed to generate signed URL for GET' },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({ signedUrl });
+  } catch (error) {
+    console.error('Unexpected error in /api/get-signed-url:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/components/ThumbnailUploader.tsx
+++ b/components/ThumbnailUploader.tsx
@@ -34,7 +34,7 @@ interface UploadedFile {
   name: string;
   url: string;
   signedUrl?: string;
-  signedUrlError?: string; // To track errors fetching the signed URL
+  signedUrlError?: string;
 }
 
 interface ImageValidationResult {

--- a/components/ThumbnailUploader.tsx
+++ b/components/ThumbnailUploader.tsx
@@ -33,6 +33,8 @@ interface UploadingFile {
 interface UploadedFile {
   name: string;
   url: string;
+  signedUrl?: string;
+  signedUrlError?: string; // To track errors fetching the signed URL
 }
 
 interface ImageValidationResult {
@@ -117,9 +119,7 @@ function ThumbnailUploader({
     const isValid = await validateImage(file);
     if (!isValid) return;
 
-    // Show loading message while getting the presigned URL
     const loadingMessage = message.loading('Authenticating Upload', 0);
-
     setUploadingFile({ file, progress: 0 });
 
     try {
@@ -141,7 +141,6 @@ function ThumbnailUploader({
       }: { uploadUrl: string; fileUrl: string; fileExists: boolean } =
         await res.json();
 
-      // Remove loading message
       loadingMessage();
 
       if (fileExists) {
@@ -159,12 +158,11 @@ function ThumbnailUploader({
             setUploadedFile(null);
           },
         });
-        return; // Prevents duplicate execution
+        return;
       }
 
       await proceedWithUpload(file, uploadUrl, fileUrl, onProgress);
     } catch (error) {
-      // Remove loading message
       loadingMessage();
       console.error('Upload failed:', error);
       message.error('Upload failed, please try again.');
@@ -191,6 +189,7 @@ function ThumbnailUploader({
       message.success('Thumbnail uploaded successfully!');
       setUploadingFile(null);
       setUploadedFile({ name: file.name, url: fileUrl });
+      fetchSignedUrl(fileUrl);
     } catch (error) {
       closeUploadingMessage();
       console.error('Upload failed:', error);
@@ -209,7 +208,6 @@ function ThumbnailUploader({
       xhr.open('PUT', uploadUrl, true);
       xhr.setRequestHeader('Content-Type', file.type);
 
-      // Progress event listener
       xhr.upload.onprogress = (event) => {
         if (event.lengthComputable) {
           const percentComplete = (event.loaded / event.total) * 100;
@@ -233,12 +231,42 @@ function ThumbnailUploader({
     });
   };
 
+  const fetchSignedUrl = async (fileUrl: string) => {
+    try {
+      const res = await fetch('/api/get-signed-url', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url: fileUrl }),
+      });
+
+      if (!res.ok) {
+        const errorBody = await res.json();
+        console.error(
+          'Failed to get signed URL:',
+          errorBody.error || res.statusText
+        );
+        setUploadedFile((prev) =>
+          prev ? { ...prev, signedUrlError: 'Failed to load thumbnail.' } : null
+        );
+        return;
+      }
+
+      const { signedUrl } = await res.json();
+      setUploadedFile((prev) => (prev ? { ...prev, signedUrl } : null));
+    } catch (error) {
+      console.error('Error fetching signed URL:', error);
+      setUploadedFile((prev) =>
+        prev ? { ...prev, signedUrlError: 'Error fetching thumbnail.' } : null
+      );
+    }
+  };
+
   const clearErrorsWithAnimation = () => {
     setIsRemovingErrors(true);
     setTimeout(() => {
-      setImageValidation(null); // Remove validation errors AFTER fade-out
+      setImageValidation(null);
       setIsRemovingErrors(false);
-    }, 200); // Matches animation duration (0.2s)
+    }, 200);
   };
 
   const getS3Uri = (url: string): string => {
@@ -372,7 +400,7 @@ function ThumbnailUploader({
             >
               <h3>Thumbnail Uploaded</h3>
               <Image
-                src={uploadedFile.url}
+                src={uploadedFile.signedUrl}
                 alt="Uploaded thumbnail"
                 style={{
                   maxWidth: '100%',
@@ -391,7 +419,6 @@ function ThumbnailUploader({
                   </Button>
                 </List.Item>
               </List>
-              {/*  Change the button based on insideDrawer */}
               <Button
                 type="primary"
                 onClick={() => {

--- a/utils/s3.ts
+++ b/utils/s3.ts
@@ -23,7 +23,6 @@ async function assumeRole() {
   };
 
   const command = new AssumeRoleCommand(roleParams);
-  console.log({ command });
   const response = await sts.send(command);
 
   if (
@@ -95,4 +94,27 @@ export async function generateSignedUrl(
   );
 
   return formatUrl(signedUrlObject);
+}
+
+export async function getSignedUrlForGetObject(
+  key: string
+): Promise<string | undefined> {
+  try {
+    const presigner = await createPresigner();
+    const url = parseUrl(
+      `https://${bucketName}.s3.${process.env.AWS_REGION}.amazonaws.com/${key}`
+    );
+
+    const signedUrlObject = await presigner.presign(
+      new HttpRequest({
+        ...url,
+        method: 'GET',
+      })
+    );
+
+    return formatUrl(signedUrlObject);
+  } catch (error) {
+    console.error('Error generating signed URL for GET object:', error);
+    return undefined;
+  }
 }


### PR DESCRIPTION
This should be the final ticket to close out #4  and #59 

The uploaded thumbnails are not public, so the app needs to obtain a signed URL to display the preview.

This adds a new endpoint to retrieve the signed URL of the newly uploaded object.  The frontend then uses that signed url to display a preview image of the recently uploaded thumbnail