### PR TITLE
validate start date is before end date

### DIFF
--- a/__tests__/utils/FormValidation.test.ts
+++ b/__tests__/utils/FormValidation.test.ts
@@ -122,4 +122,19 @@ describe('customValidate', () => {
     ).not.toHaveBeenCalled();
     expect(mockErrors.temporal_extent.enddate.addError).not.toHaveBeenCalled();
   });
+
+  it("should add an error if 'startdate is after 'enddate'", () => {
+    const formData = {
+      temporal_extent: {
+        startdate: '2025-01-01T00:00:00.001Z',
+        enddate: '2025-01-01T00:00:00.000Z',
+      },
+    };
+
+    customValidate(formData, mockErrors);
+
+    expect(mockErrors.temporal_extent.enddate.addError).toHaveBeenCalledWith(
+      'End Date must be after Start Date.'
+    );
+  });
 });

--- a/utils/CustomValidation.ts
+++ b/utils/CustomValidation.ts
@@ -55,6 +55,24 @@ export const customValidate = (formData: any, errors: any) => {
         );
       }
     }
+
+    if (
+      typeof startdate === 'string' &&
+      startdate !== '' &&
+      rfc3339Regex.test(startdate) &&
+      typeof enddate === 'string' &&
+      enddate !== '' &&
+      rfc3339Regex.test(enddate)
+    ) {
+      const startDateObj = new Date(startdate);
+      const endDateObj = new Date(enddate);
+
+      if (startDateObj.getTime() >= endDateObj.getTime()) {
+        errors.temporal_extent?.enddate?.addError(
+          'End Date must be after Start Date.'
+        );
+      }
+    }
   }
 
   return errors;


### PR DESCRIPTION
this addresses #83  to ensure that the temporal extent End Date field is actually after the Start date.  The fields can still be empty, but if they are both used they must be in chronological order