### PR TITLE
Add collapsible discovery section for some rows of Discovery Items

### DIFF
--- a/FormSchemas/uischema.json
+++ b/FormSchemas/uischema.json
@@ -58,8 +58,10 @@
           "bucket": 8
         },
         {
-          "filename_regex": 12,
-          "datetime_range": 12
+          "filename_regex": 24
+        },
+        {
+          "datetime_range": 24
         },
         {
           "stac_extensions": 12,

--- a/__tests__/playwright/CreateIngestPage.test.tsx
+++ b/__tests__/playwright/CreateIngestPage.test.tsx
@@ -1,6 +1,7 @@
 import { expect, test } from '@/__tests__/playwright/setup-msw';
 import { validateFormFields } from '../playwright/utils/ValidateFormFields';
 import { HttpResponse } from 'msw';
+import { forEach } from 'lodash';
 
 const requiredConfig = {
   collection: 'test-collection',
@@ -383,6 +384,68 @@ test.describe('Create Ingest Page', () => {
     const errorScreenshot = await page.screenshot();
     testInfo.attach('error modal for duplicate collection name', {
       body: errorScreenshot,
+      contentType: 'image/png',
+    });
+  });
+
+  test.only('Hide extended Discovery Items fields by default', async ({
+    page,
+  }, testInfo) => {
+    await test.step('Navigate to the Create Ingest page', async () => {
+      await page.goto('/create-ingest');
+    });
+
+    await expect(
+      page.getByRole('button', { name: /more options/i, expanded: false }),
+      'more options should not be expanded'
+    ).toBeVisible();
+
+    const DiscoveryFieldset = page.locator('#root_discovery_items');
+    const hiddenFields = [
+      'Datetime Range',
+      'Start Datetime',
+      'End Datetime',
+      'Id Regex',
+      'Id Template',
+      'Use Multithreading',
+    ];
+
+    for (const field of hiddenFields) {
+      await expect(
+        DiscoveryFieldset.getByLabel(field),
+        `${field} should be hidden`
+      ).toBeHidden();
+    }
+
+    const collapsedScreenshot = await DiscoveryFieldset.screenshot({
+      fullPage: true,
+    });
+    testInfo.attach('collapsed Discovery Items', {
+      body: collapsedScreenshot,
+      contentType: 'image/png',
+    });
+    await test.step('click more option button', async () => {
+      await page
+        .getByRole('button', { name: /more options/i, expanded: false })
+        .click();
+    });
+
+    await expect(
+      page.getByRole('button', { name: /more options/i, expanded: true }),
+      'more options should be expanded'
+    ).toBeVisible();
+
+    for (const field of hiddenFields) {
+      await expect(
+        DiscoveryFieldset.getByLabel(field),
+        `${field} should be visible`
+      ).toBeVisible();
+    }
+    const expandedScreenshot = await DiscoveryFieldset.screenshot({
+      fullPage: true,
+    });
+    testInfo.attach('Expanded Discovery Items', {
+      body: expandedScreenshot,
       contentType: 'image/png',
     });
   });

--- a/__tests__/playwright/CreateIngestPage.test.tsx
+++ b/__tests__/playwright/CreateIngestPage.test.tsx
@@ -417,9 +417,7 @@ test.describe('Create Ingest Page', () => {
       ).toBeHidden();
     }
 
-    const collapsedScreenshot = await DiscoveryFieldset.screenshot({
-      fullPage: true,
-    });
+    const collapsedScreenshot = await DiscoveryFieldset.screenshot();
     testInfo.attach('collapsed Discovery Items', {
       body: collapsedScreenshot,
       contentType: 'image/png',
@@ -441,9 +439,7 @@ test.describe('Create Ingest Page', () => {
         `${field} should be visible`
       ).toBeVisible();
     }
-    const expandedScreenshot = await DiscoveryFieldset.screenshot({
-      fullPage: true,
-    });
+    const expandedScreenshot = await DiscoveryFieldset.screenshot();
     testInfo.attach('Expanded Discovery Items', {
       body: expandedScreenshot,
       contentType: 'image/png',

--- a/__tests__/playwright/CreateIngestPage.test.tsx
+++ b/__tests__/playwright/CreateIngestPage.test.tsx
@@ -388,7 +388,7 @@ test.describe('Create Ingest Page', () => {
     });
   });
 
-  test.only('Hide extended Discovery Items fields by default', async ({
+  test('Hide extended Discovery Items fields by default', async ({
     page,
   }, testInfo) => {
     await test.step('Navigate to the Create Ingest page', async () => {

--- a/__tests__/playwright/utils/ValidateFormFields.tsx
+++ b/__tests__/playwright/utils/ValidateFormFields.tsx
@@ -36,15 +36,17 @@ export async function validateFormFields(page: Page, expectedValues: any) {
     expectedValues.temporal_extent.enddate
   );
   // Locate the fieldset that contains "Discovery Items-1"
-  const fieldsetLocator = page.locator('fieldset', {
-    hasText: 'Discovery Items-1',
+  const DiscoveryField = page.locator('.form-group.field.field-string', {
+    hasText: 'Discovery',
   });
 
-  // Locate the span inside it with the text "s3"
-  const s3Locator = fieldsetLocator.locator('span.ant-select-selection-item', {
-    hasText: expectedValues.discovery_items[0].discovery,
-  });
-  await expect(s3Locator).toBeVisible();
+  await expect(
+    DiscoveryField.getByText(expectedValues.discovery_items[0].discovery, {
+      exact: true,
+    }),
+    'Discovery dropdown should have correct value'
+  ).toBeVisible();
+
   await expect(page.getByLabel('Prefix')).toHaveValue(
     expectedValues.discovery_items[0].prefix
   );

--- a/__tests__/playwright/utils/ValidateFormFields.tsx
+++ b/__tests__/playwright/utils/ValidateFormFields.tsx
@@ -35,7 +35,7 @@ export async function validateFormFields(page: Page, expectedValues: any) {
   await expect(page.getByLabel('End Date').first()).toHaveValue(
     expectedValues.temporal_extent.enddate
   );
-  // Locate the fieldset that contains "Discovery Items-1"
+
   const DiscoveryField = page.locator('.form-group.field.field-string', {
     hasText: 'Discovery',
   });

--- a/utils/DiscoveryItemObjectFieldTemplate.tsx
+++ b/utils/DiscoveryItemObjectFieldTemplate.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import React from 'react';
+import { Collapse, Row, Col } from 'antd';
+import {
+  FormContextType,
+  ObjectFieldTemplateProps,
+  RJSFSchema,
+  StrictRJSFSchema,
+  getUiOptions,
+} from '@rjsf/utils';
+
+const { Panel } = Collapse;
+
+export default function DiscoveryItemObjectFieldTemplate<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F extends FormContextType = any,
+>(props: ObjectFieldTemplateProps<T, S, F>) {
+  const { properties, uiSchema, idSchema } = props;
+
+  const uiOptions = getUiOptions(uiSchema);
+  const rowGutter = (props.formContext as any)?.rowGutter || 12;
+
+  // We want the "More Options" panel to be collapsed by default
+  const defaultActiveKeys: string[] = [];
+
+  // Get the grid definition for this item
+  const itemUiGrid = uiSchema?.['ui:grid'] as
+    | { [key: string]: number }[]
+    | undefined;
+
+  if (!itemUiGrid) {
+    // Fallback if no ui:grid is defined for the item
+    return (
+      <Row gutter={rowGutter}>
+        {properties
+          .filter((e) => !e.hidden)
+          .map((element) => (
+            <Col key={element.name} span={24}>
+              {element.content}
+            </Col>
+          ))}
+      </Row>
+    );
+  }
+
+  // Helper function to render a single row from the ui:grid definition
+  const renderGridRow = (rowIndex: number) => {
+    if (!itemUiGrid[rowIndex]) return null;
+
+    const rowDefinition = itemUiGrid[rowIndex];
+    return (
+      <Row key={`grid-row-${rowIndex}`} gutter={rowGutter}>
+        {Object.keys(rowDefinition).map((fieldName) => {
+          const element = properties.find((p) => p.name === fieldName);
+          return element ? (
+            <Col key={element.name} span={rowDefinition[fieldName]}>
+              {element.content}
+            </Col>
+          ) : null;
+        })}
+      </Row>
+    );
+  };
+
+  return (
+    <>
+      {/* Always Visible Sections */}
+      {renderGridRow(0)} {/* discovery, prefix, bucket */}
+      {renderGridRow(1)} {/* filename_regex */}
+      {/* Collapsible "More Options" Section */}
+      {/* The Collapse component wraps only the "More Options" panel */}
+      <Collapse defaultActiveKey={defaultActiveKeys}>
+        <Panel header="More Options" key="more-options">
+          {renderGridRow(2)} {/* datetime_range */}
+          {renderGridRow(3)} {/* stac_extensions, links */}
+          {renderGridRow(4)}{' '}
+          {/* start_datetime, end_datetime, single_datetime */}
+          {renderGridRow(5)} {/* id_regex, id_template, use_multithreading */}
+        </Panel>
+      </Collapse>
+    </>
+  );
+}

--- a/utils/ObjectFieldTemplate.tsx
+++ b/utils/ObjectFieldTemplate.tsx
@@ -1,4 +1,4 @@
-'use client'; // Ensure this component is client-side only
+'use client';
 
 import '@ant-design/v5-patch-for-react-19';
 import React, { useState } from 'react';
@@ -29,6 +29,7 @@ import { CloudUploadOutlined, ImportOutlined } from '@ant-design/icons';
 import COGDrawerViewer from '@/components/COGDrawerViewer';
 import ThumbnailUploaderDrawer from '@/components/ThumbnailUploaderDrawer';
 import { Alert } from 'antd';
+import DiscoveryItemObjectFieldTemplate from './DiscoveryItemObjectFieldTemplate'; // Import the specific template
 
 const DESCRIPTION_COL_STYLE = {
   paddingBottom: '8px',
@@ -166,6 +167,13 @@ export default function ObjectFieldTemplate<
   const isDashboardField = (element: ObjectFieldTemplatePropertyType) =>
     element.name === 'dashboard' &&
     element.content?.props?.idSchema?.$id.includes('renders');
+  const isDiscoveryItem =
+    idSchema.$id.startsWith('root_discovery_items_') &&
+    schema.type === 'object';
+
+  if (isDiscoveryItem) {
+    return <DiscoveryItemObjectFieldTemplate {...props} />;
+  }
 
   return (
     <ConfigConsumer>


### PR DESCRIPTION
for some parts of the items in the Discovery Items, users rarely enter the optional fields and find them confusing.  It would be nice to hide them unless a user expands to see the additional rows
<img width="40%" alt="Screenshot 2025-05-30 at 4 58 07 PM" src="https://github.com/user-attachments/assets/1dd8e52d-41b2-465d-82fc-5fdb031a1047" /><img width="40%" alt="Screenshot 2025-05-30 at 4 57 58 PM" src="https://github.com/user-attachments/assets/5ccb1266-4e80-44c9-aac4-1d321263a706" />
