### PR TITLE
add test button and validation api call for sample_files

### DIFF
--- a/FormSchemas/datasets/uischema.json
+++ b/FormSchemas/datasets/uischema.json
@@ -182,5 +182,10 @@
       "size": "large",
       "block": "true"
     }
+  },
+  "sample_files": {
+    "items": {
+      "ui:widget": "testableUrl"
+    }
   }
 }

--- a/__tests__/utils/AssetsField.test.tsx
+++ b/__tests__/utils/AssetsField.test.tsx
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { FieldProps } from '@rjsf/utils';
+import AssetsField from '@/utils/AssetsField';
+
+// We will test against the real child components, so the mock is removed.
+// We still need to mock the RJSF-provided fields/templates.
+
+const MockSchemaField = vi.fn(
+  ({ formData, onChange }: FieldProps<Record<string, any>>) => (
+    <div>
+      {/* Simulate a change within the asset's form */}
+      <button onClick={() => onChange({ ...formData, title: 'Updated Title' })}>
+        Update Asset
+      </button>
+    </div>
+  )
+);
+
+const MockTitleField = ({ title }: { title: string }) => <h1>{title}</h1>;
+const MockDescriptionField = ({ description }: { description: string }) => (
+  <p>{description}</p>
+);
+
+describe('AssetsField', () => {
+  const mockOnChange = vi.fn();
+  let baseProps: FieldProps;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    baseProps = {
+      schema: {
+        type: 'object',
+        title: 'Assets',
+        description: 'A list of assets.',
+        additionalProperties: {
+          type: 'object',
+          properties: {
+            href: { type: 'string' },
+            title: { type: 'string' },
+          },
+        },
+      },
+      formData: {
+        thumbnail: { href: './thumb.png', title: 'Thumbnail' },
+        data: { href: './data.tiff', title: 'Data' },
+      },
+      onChange: mockOnChange,
+      registry: {
+        fields: {
+          SchemaField: MockSchemaField,
+        },
+        templates: {
+          TitleFieldTemplate: MockTitleField,
+          DescriptionFieldTemplate: MockDescriptionField,
+        },
+      },
+      idSchema: { $id: 'root_assets' },
+      name: 'assets',
+      uiSchema: {},
+      disabled: false,
+      readonly: false,
+      formContext: {},
+    } as unknown as FieldProps;
+  });
+
+  it('should render initial assets correctly', () => {
+    render(<AssetsField {...baseProps} />);
+
+    expect(screen.getByRole('heading', { name: 'Assets' })).toBeInTheDocument();
+    expect(screen.getByText('A list of assets.')).toBeInTheDocument();
+
+    // Find inputs by their displayed value
+    expect(screen.getByDisplayValue('thumbnail')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('data')).toBeInTheDocument();
+
+    expect(MockSchemaField).toHaveBeenCalledTimes(2);
+  });
+
+  it('should add a new asset when the add button is clicked', () => {
+    render(<AssetsField {...baseProps} />);
+
+    // Find the add button by its tooltip title, which is more accessible
+    const addButton = screen.getByRole('button', { name: /Add Asset/i });
+    fireEvent.click(addButton);
+
+    expect(mockOnChange).toHaveBeenCalledTimes(1);
+    const updatedFormData = mockOnChange.mock.calls[0][0];
+
+    expect(Object.keys(updatedFormData).length).toBe(3);
+    expect(updatedFormData).toHaveProperty('new_asset');
+  });
+
+  it('should remove an asset', () => {
+    render(<AssetsField {...baseProps} />);
+
+    // Find the specific card containing the 'thumbnail' asset
+    const thumbnailInput = screen.getByDisplayValue('thumbnail');
+    const thumbnailCard = thumbnailInput.closest(
+      '.ant-card-body'
+    ) as HTMLElement;
+
+    // Find the remove button *within* that specific card
+    const removeButton = within(thumbnailCard!).getByRole('button', {
+      name: /delete/i,
+    });
+    fireEvent.click(removeButton);
+
+    expect(mockOnChange).toHaveBeenCalledTimes(1);
+    const updatedFormData = mockOnChange.mock.calls[0][0];
+
+    expect(updatedFormData).not.toHaveProperty('thumbnail');
+    expect(Object.keys(updatedFormData).length).toBe(1);
+  });
+
+  it('should handle changing an asset key', () => {
+    render(<AssetsField {...baseProps} />);
+
+    const keyInput = screen.getByDisplayValue('thumbnail');
+    fireEvent.change(keyInput, { target: { value: 'new_thumbnail_key' } });
+    fireEvent.blur(keyInput);
+
+    expect(mockOnChange).toHaveBeenCalledTimes(1);
+    const updatedFormData = mockOnChange.mock.calls[0][0];
+
+    expect(updatedFormData).not.toHaveProperty('thumbnail');
+    expect(updatedFormData).toHaveProperty('new_thumbnail_key');
+    expect(updatedFormData.new_thumbnail_key.title).toBe('Thumbnail');
+  });
+
+  it('should prevent renaming an existing key', () => {
+    render(<AssetsField {...baseProps} />);
+
+    const keyInput = screen.getByDisplayValue('thumbnail');
+    // Try to rename 'thumbnail' to 'data' (which already exists)
+    fireEvent.change(keyInput, { target: { value: 'data' } });
+    fireEvent.blur(keyInput);
+
+    expect(mockOnChange).toHaveBeenCalledTimes(1);
+    // The component should call onChange with the *original* data, effectively cancelling the rename
+    expect(mockOnChange).toHaveBeenCalledWith(baseProps.formData);
+  });
+
+  it('should update an asset’s value when its SchemaField changes', () => {
+    render(<AssetsField {...baseProps} />);
+
+    // Find all update buttons and click the first one
+    const updateButtons = screen.getAllByRole('button', {
+      name: 'Update Asset',
+    });
+    fireEvent.click(updateButtons[0]);
+
+    expect(mockOnChange).toHaveBeenCalledTimes(1);
+    const updatedFormData = mockOnChange.mock.calls[0][0];
+
+    expect(updatedFormData.thumbnail.title).toBe('Updated Title');
+  });
+
+  it('should handle adding more than one new asset', () => {
+    const { rerender } = render(<AssetsField {...baseProps} />);
+    const addButton = screen.getByRole('button', { name: /Add Asset/i });
+
+    // --- First Add ---
+    fireEvent.click(addButton);
+
+    // Verify the first call to onChange
+    expect(mockOnChange).toHaveBeenCalledTimes(1);
+    const firstUpdate = mockOnChange.mock.calls[0][0];
+    expect(Object.keys(firstUpdate).length).toBe(3);
+    expect(firstUpdate).toHaveProperty('new_asset');
+
+    // --- Second Add ---
+    // Rerender the component with the updated form data
+    rerender(<AssetsField {...baseProps} formData={firstUpdate} />);
+
+    // Click the add button again
+    fireEvent.click(addButton);
+
+    // Verify the second call to onChange
+    expect(mockOnChange).toHaveBeenCalledTimes(2);
+    const secondUpdate = mockOnChange.mock.calls[1][0];
+    expect(Object.keys(secondUpdate).length).toBe(4);
+    // Check for the next unique key, which should be 'new_asset_1'
+    expect(secondUpdate).toHaveProperty('new_asset_1');
+  });
+});

--- a/__tests__/utils/BboxField.test.tsx
+++ b/__tests__/utils/BboxField.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { FieldProps } from '@rjsf/utils';
+import BboxField from '@/utils/BboxField';
+
+// Mock the Ant Design InputNumber to simplify testing
+vi.mock('antd', async (importOriginal) => {
+  const antd = await importOriginal<typeof import('antd')>();
+  const MockInputNumber = ({
+    value,
+    onChange,
+    placeholder,
+    disabled,
+  }: {
+    value: number | null;
+    onChange: (val: number | null) => void;
+    placeholder: string;
+    disabled: boolean;
+  }) => (
+    <input
+      type="number"
+      value={value ?? ''}
+      placeholder={placeholder}
+      disabled={disabled}
+      onChange={(e) =>
+        onChange(e.target.value === '' ? null : Number(e.target.value))
+      }
+    />
+  );
+  return { ...antd, InputNumber: MockInputNumber };
+});
+
+describe('BboxField', () => {
+  const mockOnChange = vi.fn();
+  const mockOnBlur = vi.fn();
+  const mockOnFocus = vi.fn();
+  let baseProps: FieldProps;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    baseProps = {
+      formData: [-105.0, 40.0, -104.0, 41.0], // xmin, ymin, xmax, ymax
+      onChange: mockOnChange,
+      onBlur: mockOnBlur,
+      onFocus: mockOnFocus,
+      idSchema: { $id: 'root_bbox' },
+      schema: {},
+      name: 'bbox',
+      uiSchema: {},
+      disabled: false,
+      readonly: false,
+      formContext: {},
+      registry: {} as any,
+    };
+  });
+
+  it('should render the initial values in the correct inputs', () => {
+    render(<BboxField {...baseProps} />);
+
+    expect(screen.getByPlaceholderText('xmin')).toHaveValue(-105.0);
+    expect(screen.getByPlaceholderText('ymin')).toHaveValue(40.0);
+    expect(screen.getByPlaceholderText('xmax')).toHaveValue(-104.0);
+    expect(screen.getByPlaceholderText('ymax')).toHaveValue(41.0);
+  });
+
+  it('should render empty inputs if formData is undefined', () => {
+    render(<BboxField {...baseProps} formData={undefined} />);
+
+    expect(screen.getByPlaceholderText('xmin')).toHaveValue(null);
+    expect(screen.getByPlaceholderText('ymin')).toHaveValue(null);
+    expect(screen.getByPlaceholderText('xmax')).toHaveValue(null);
+    expect(screen.getByPlaceholderText('ymax')).toHaveValue(null);
+  });
+
+  it('should call onChange with the updated array when xmin changes', () => {
+    render(<BboxField {...baseProps} />);
+    const xminInput = screen.getByPlaceholderText('xmin');
+    fireEvent.change(xminInput, { target: { value: '-105.5' } });
+
+    expect(mockOnChange).toHaveBeenCalledTimes(1);
+    expect(mockOnChange).toHaveBeenCalledWith([-105.5, 40.0, -104.0, 41.0]);
+  });
+
+  it('should call onChange with the updated array when ymin changes', () => {
+    render(<BboxField {...baseProps} />);
+    const yminInput = screen.getByPlaceholderText('ymin');
+    fireEvent.change(yminInput, { target: { value: '39.5' } });
+
+    expect(mockOnChange).toHaveBeenCalledTimes(1);
+    expect(mockOnChange).toHaveBeenCalledWith([-105.0, 39.5, -104.0, 41.0]);
+  });
+
+  it('should call onChange with the updated array when xmax changes', () => {
+    render(<BboxField {...baseProps} />);
+    const xmaxInput = screen.getByPlaceholderText('xmax');
+    fireEvent.change(xmaxInput, { target: { value: '-103.5' } });
+
+    expect(mockOnChange).toHaveBeenCalledTimes(1);
+    expect(mockOnChange).toHaveBeenCalledWith([-105.0, 40.0, -103.5, 41.0]);
+  });
+
+  it('should call onChange with the updated array when ymax changes', () => {
+    render(<BboxField {...baseProps} />);
+    const ymaxInput = screen.getByPlaceholderText('ymax');
+    fireEvent.change(ymaxInput, { target: { value: '41.5' } });
+
+    expect(mockOnChange).toHaveBeenCalledTimes(1);
+    expect(mockOnChange).toHaveBeenCalledWith([-105.0, 40.0, -104.0, 41.5]);
+  });
+
+  it('should disable all inputs when the disabled prop is true', () => {
+    render(<BboxField {...baseProps} disabled={true} />);
+
+    expect(screen.getByPlaceholderText('xmin')).toBeDisabled();
+    expect(screen.getByPlaceholderText('ymin')).toBeDisabled();
+    expect(screen.getByPlaceholderText('xmax')).toBeDisabled();
+    expect(screen.getByPlaceholderText('ymax')).toBeDisabled();
+  });
+});

--- a/__tests__/utils/IntervalField.test.tsx
+++ b/__tests__/utils/IntervalField.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { FieldProps } from '@rjsf/utils';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import IntervalField from '@/utils/IntervalField';
+
+// Extend dayjs with the utc plugin for consistent ISO string conversion
+dayjs.extend(utc);
+
+// Mock the Ant Design DatePicker to simplify testing
+vi.mock('antd', async (importOriginal) => {
+  const antd = await importOriginal<typeof import('antd')>();
+
+  // AntD's DatePicker onChange passes a dayjs object.
+  const MockDatePicker = ({
+    value,
+    onChange,
+    placeholder,
+    disabled,
+    format,
+  }: {
+    value: dayjs.Dayjs | null;
+    onChange: (date: dayjs.Dayjs | null) => void;
+    placeholder: string;
+    disabled: boolean;
+    format: string;
+  }) => (
+    <input
+      type="text"
+      // The component passes a dayjs object to 'value', so we format it for the input
+      value={value ? value.format(format) : ''}
+      placeholder={placeholder}
+      disabled={disabled}
+      // Simulate a new date selection by creating a dayjs object from the input string
+      onChange={(e) => onChange(e.target.value ? dayjs(e.target.value) : null)}
+    />
+  );
+  return { ...antd, DatePicker: MockDatePicker };
+});
+
+describe('IntervalField', () => {
+  const mockOnChange = vi.fn();
+  const mockOnBlur = vi.fn();
+  const mockOnFocus = vi.fn();
+  let baseProps: FieldProps;
+
+  const initialStartDate = '2025-07-10T12:00:00.000Z';
+  const initialEndDate = '2025-07-25T18:30:00.000Z';
+  const displayFormat = 'YYYY-MM-DD HH:mm:ss';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    baseProps = {
+      formData: [initialStartDate, initialEndDate],
+      onChange: mockOnChange,
+      onBlur: mockOnBlur,
+      onFocus: mockOnFocus,
+      idSchema: { $id: 'root_interval' },
+      schema: {},
+      name: 'interval',
+      uiSchema: {},
+      disabled: false,
+      readonly: false,
+      formContext: {},
+      registry: {} as any,
+    };
+  });
+
+  it('should render the initial date values formatted correctly', () => {
+    render(<IntervalField {...baseProps} />);
+
+    // Check that the ISO strings from formData are formatted for display
+    expect(screen.getByPlaceholderText('Start Date')).toHaveValue(
+      dayjs(initialStartDate).format(displayFormat)
+    );
+    expect(screen.getByPlaceholderText('End Date')).toHaveValue(
+      dayjs(initialEndDate).format(displayFormat)
+    );
+  });
+
+  it('should render empty inputs if formData is undefined', () => {
+    render(<IntervalField {...baseProps} formData={undefined} />);
+
+    expect(screen.getByPlaceholderText('Start Date')).toHaveValue('');
+    expect(screen.getByPlaceholderText('End Date')).toHaveValue('');
+  });
+
+  it('should call onChange with the updated start date as an ISO string', () => {
+    render(<IntervalField {...baseProps} />);
+    const newDate = '2025-08-01T00:00:00.000Z';
+
+    const startDateInput = screen.getByPlaceholderText('Start Date');
+    fireEvent.change(startDateInput, { target: { value: newDate } });
+
+    expect(mockOnChange).toHaveBeenCalledTimes(1);
+    // The component should convert the dayjs object back to an ISO string
+    expect(mockOnChange).toHaveBeenCalledWith([newDate, initialEndDate]);
+  });
+
+  it('should call onChange with the updated end date as an ISO string', () => {
+    render(<IntervalField {...baseProps} />);
+    const newDate = '2025-09-15T00:00:00.000Z';
+
+    const endDateInput = screen.getByPlaceholderText('End Date');
+    fireEvent.change(endDateInput, { target: { value: newDate } });
+
+    expect(mockOnChange).toHaveBeenCalledTimes(1);
+    // The component should convert the dayjs object back to an ISO string
+    expect(mockOnChange).toHaveBeenCalledWith([initialStartDate, newDate]);
+  });
+
+  it('should disable both inputs when the disabled prop is true', () => {
+    render(<IntervalField {...baseProps} disabled={true} />);
+
+    expect(screen.getByPlaceholderText('Start Date')).toBeDisabled();
+    expect(screen.getByPlaceholderText('End Date')).toBeDisabled();
+  });
+});

--- a/__tests__/utils/TestableUrlWidget.test.tsx
+++ b/__tests__/utils/TestableUrlWidget.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { TestableUrlWidget } from '@/utils/TestableUrlWidget';
+import { WidgetProps } from '@rjsf/utils';
+
+// Mock Ant Design components
+vi.mock('antd', async (importOriginal) => {
+  const antd = await importOriginal<typeof import('antd')>();
+  return {
+    ...antd,
+    Typography: {
+      ...antd.Typography,
+      Text: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+    },
+  };
+});
+
+describe('TestableUrlWidget', () => {
+  const mockOnChange = vi.fn();
+  const mockOnBlur = vi.fn();
+  const mockOnFocus = vi.fn();
+
+  const baseProps: WidgetProps = {
+    id: 'test-widget',
+    name: 'test-name',
+    label: 'Test Label',
+    value: '',
+    onChange: mockOnChange,
+    onBlur: mockOnBlur,
+    onFocus: mockOnFocus,
+    disabled: false,
+    readonly: false,
+    schema: {},
+    options: {},
+    registry: {} as any,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn();
+  });
+
+  describe('API Validation and Rendering', () => {
+    it('should render correctly in its initial state', () => {
+      render(<TestableUrlWidget {...baseProps} value="http://initial.url" />);
+      expect(screen.getByRole('textbox')).toHaveValue('http://initial.url');
+      const validateButton = screen.getByRole('button', { name: /validate/i });
+      expect(validateButton).toBeVisible();
+      expect(validateButton).toBeEnabled();
+    });
+
+    it('should show a "validated" state on successful API call', async () => {
+      (global.fetch as Mock).mockResolvedValue({ ok: true });
+      render(<TestableUrlWidget {...baseProps} value="http://valid.url" />);
+      fireEvent.click(screen.getByRole('button', { name: /validate/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: /validated/i })
+        ).toBeVisible();
+      });
+      expect(screen.queryByText(/Validation failed/)).not.toBeInTheDocument();
+    });
+
+    it('should show an "error" state on failed API call', async () => {
+      (global.fetch as Mock).mockResolvedValue({ ok: false });
+      render(<TestableUrlWidget {...baseProps} value="http://invalid.url" />);
+      fireEvent.click(screen.getByRole('button', { name: /validate/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /invalid/i })).toBeVisible();
+      });
+      expect(screen.getByText(/Validation failed/)).toBeVisible();
+    });
+
+    it('should show an "error" state on network failure', async () => {
+      (global.fetch as Mock).mockRejectedValue(new Error('Network failure'));
+      render(<TestableUrlWidget {...baseProps} value="http://network.error" />);
+      fireEvent.click(screen.getByRole('button', { name: /validate/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /invalid/i })).toBeVisible();
+      });
+      expect(screen.getByText(/Validation failed/)).toBeVisible();
+    });
+
+    it('should disable the input and button when disabled prop is true', () => {
+      render(<TestableUrlWidget {...baseProps} disabled={true} />);
+      expect(screen.getByRole('textbox')).toBeDisabled();
+      expect(screen.getByRole('button', { name: /validate/i })).toBeDisabled();
+    });
+  });
+
+  describe('Debouncing', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('should handle input changes with debouncing', () => {
+      render(<TestableUrlWidget {...baseProps} />);
+      const input = screen.getByRole('textbox');
+      fireEvent.change(input, { target: { value: 'http://new.url' } });
+
+      expect(input).toHaveValue('http://new.url');
+      expect(mockOnChange).not.toHaveBeenCalled();
+
+      // Advance timers to trigger the debounced function
+      vi.advanceTimersByTime(400);
+
+      expect(mockOnChange).toHaveBeenCalledTimes(1);
+      expect(mockOnChange).toHaveBeenCalledWith('http://new.url');
+    });
+  });
+});

--- a/components/DatasetIngestionForm.tsx
+++ b/components/DatasetIngestionForm.tsx
@@ -18,6 +18,7 @@ import { JSONEditorValue } from '@/components/JSONEditor';
 import AdditionalPropertyCard from '@/components/AdditionalPropertyCard';
 import CodeEditorWidget from './CodeEditorWidget';
 import uiSchema from '@/FormSchemas/datasets/uischema.json';
+import { TestableUrlWidget } from '@/utils/TestableUrlWidget';
 
 const Form = withTheme(AntDTheme);
 
@@ -146,6 +147,7 @@ function DatasetIngestionForm({
 
   const widgets = {
     'renders.dashboard': RjsfCodeEditorWidget,
+    testableUrl: TestableUrlWidget,
   };
 
   return (

--- a/utils/AssetsField.tsx
+++ b/utils/AssetsField.tsx
@@ -159,6 +159,7 @@ const AssetsField: React.FC<FieldProps> = (props) => {
         <Col style={{ flex: '0 0 168px' }}>
           <Tooltip title="Add Asset">
             <Button
+              aria-label="Add Asset"
               type="primary"
               icon={<PlusCircleOutlined />}
               onClick={handleAddAsset}

--- a/utils/IntervalField.tsx
+++ b/utils/IntervalField.tsx
@@ -1,7 +1,6 @@
-// fields/IntervalField.tsx (or IntervalField.tsx)
 import React from 'react';
-import { FieldProps } from '@rjsf/utils'; // <-- Important: Use FieldProps
-import { DatePicker, Row, Col } from 'antd'; // No Typography here
+import { FieldProps } from '@rjsf/utils';
+import { DatePicker, Row, Col } from 'antd';
 import dayjs from 'dayjs';
 import 'dayjs/plugin/utc';
 import 'dayjs/plugin/timezone';
@@ -10,7 +9,7 @@ dayjs.extend(require('dayjs/plugin/utc'));
 dayjs.extend(require('dayjs/plugin/timezone'));
 
 const IntervalField: React.FC<FieldProps> = (props) => {
-  const { formData, onChange, disabled, readonly, idSchema } = props; // <-- Use formData from FieldProps
+  const { formData, onChange, disabled, readonly, idSchema } = props;
 
   // Ensure formData is an array, default to [null, null] if undefined
   const intervalValue =

--- a/utils/TestableUrlWidget.tsx
+++ b/utils/TestableUrlWidget.tsx
@@ -1,0 +1,134 @@
+import { WidgetProps } from '@rjsf/utils';
+import Input from 'antd/lib/input';
+import Button from 'antd/lib/button';
+import Typography from 'antd/lib/typography';
+import { useState, useEffect, useRef } from 'react';
+import { CheckOutlined, CloseCircleOutlined } from '@ant-design/icons';
+
+// Define the possible states for our validation UI
+type ValidationState = 'idle' | 'loading' | 'validated' | 'error';
+
+export const TestableUrlWidget = ({
+  id,
+  value,
+  onChange,
+  disabled,
+  readonly,
+}: WidgetProps) => {
+  const [inputValue, setInputValue] = useState(value || '');
+  const [validationState, setValidationState] =
+    useState<ValidationState>('idle');
+  const debounceTimeout = useRef<NodeJS.Timeout | null>(null);
+
+  // This effect syncs the local state if the form data is changed from elsewhere
+  useEffect(() => {
+    if (value !== inputValue) {
+      setInputValue(value || '');
+    }
+    // When the value changes externally, reset the validation state
+    setValidationState('idle');
+  }, [value]);
+
+  // Cleanup the timeout when the component unmounts
+  useEffect(() => {
+    return () => {
+      if (debounceTimeout.current) clearTimeout(debounceTimeout.current);
+    };
+  }, []);
+
+  const handleValidationClick = async () => {
+    if (!inputValue) return;
+
+    setValidationState('loading');
+    const encodedUrl = encodeURIComponent(inputValue);
+    const validationApiUrl = `https://staging.openveda.cloud/api/raster/cog/validate?strict=false&url=${encodedUrl}`;
+
+    try {
+      const response = await fetch(validationApiUrl);
+      if (response.ok) {
+        setValidationState('validated');
+      } else {
+        setValidationState('error');
+      }
+    } catch (err) {
+      console.error('Validation API request failed', err);
+      setValidationState('error');
+    }
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = e.target.value;
+    setInputValue(newValue);
+    setValidationState('idle');
+
+    if (debounceTimeout.current) clearTimeout(debounceTimeout.current);
+
+    debounceTimeout.current = setTimeout(() => {
+      onChange(newValue === '' ? undefined : newValue);
+    }, 400);
+  };
+
+  const getButtonText = () => {
+    switch (validationState) {
+      case 'loading':
+        return 'Validating';
+      case 'validated':
+        return 'Validated';
+      case 'error':
+        return 'Invalid';
+      case 'idle':
+      default:
+        return 'Validate';
+    }
+  };
+
+  return (
+    <div>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '8px',
+          width: '100%',
+        }}
+      >
+        <Input
+          value={inputValue}
+          onChange={handleInputChange}
+          id={id}
+          disabled={disabled}
+          readOnly={readonly}
+          style={{ flex: 1 }}
+        />
+        <Button
+          onClick={handleValidationClick}
+          disabled={
+            disabled || readonly || !inputValue || validationState === 'loading'
+          }
+          loading={validationState === 'loading'}
+          icon={
+            validationState === 'validated' ? (
+              <CheckOutlined />
+            ) : validationState === 'error' ? (
+              <CloseCircleOutlined />
+            ) : null
+          }
+          danger={validationState === 'error'}
+          type={validationState === 'validated' ? 'primary' : 'default'}
+          ghost={validationState === 'validated'}
+          style={{ width: '120px' }}
+        >
+          {getButtonText()}
+        </Button>
+      </div>
+      {validationState === 'error' && (
+        <Typography.Text
+          type="danger"
+          style={{ marginTop: '4px', display: 'block' }}
+        >
+          Validation failed. The URL may be invalid or unreachable.
+        </Typography.Text>
+      )}
+    </div>
+  );
+};

--- a/utils/TestableUrlWidget.tsx
+++ b/utils/TestableUrlWidget.tsx
@@ -5,7 +5,6 @@ import Typography from 'antd/lib/typography';
 import { useState, useEffect, useRef } from 'react';
 import { CheckOutlined, CloseCircleOutlined } from '@ant-design/icons';
 
-// Define the possible states for our validation UI
 type ValidationState = 'idle' | 'loading' | 'validated' | 'error';
 
 export const TestableUrlWidget = ({

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -5,6 +5,7 @@ import tsconfigPaths from 'vite-tsconfig-paths';
 export default defineConfig({
   plugins: [tsconfigPaths(), react()],
   test: {
+    globals: true,
     environment: 'jsdom',
     setupFiles: ['./vitest-setup.tsx'],
     exclude: ['**/__tests__/playwright/**', '**/node_modules/**'],
@@ -13,6 +14,7 @@ export default defineConfig({
       reporter: ['text', 'json', 'html'],
       include: [
         'utils/**/*.ts',
+        'utils/**/*.tsx',
         'components/*.tsx',
         'app/**/tsx',
         'hooks/*.ts',


### PR DESCRIPTION
closes #82 
This makes an API call to the staging validate url: https://staging.openveda.cloud/api/raster/cog/validate?strict=false&url=${encodedUrl}

It is considered valid if a `200` is recieved. 

This will give feedback for each sample feedback as validated, failed, or not yet validated:

<img width="1633" alt="Screenshot 2025-07-09 at 3 15 50 PM" src="https://github.com/user-attachments/assets/8a2bd73e-8d51-41a4-86b6-71b100f760f5" />
