### PR TITLE
Manually set defaults to allow deletion via json editor

### DIFF
--- a/FormSchemas/datasets/datasetSchema.json
+++ b/FormSchemas/datasets/datasetSchema.json
@@ -11,7 +11,6 @@
     "sample_files",
     "data_type",
     "providers",
-    "item_assets",
     "renders"
   ],
   "properties": {
@@ -208,23 +207,19 @@
           "type": "object",
           "properties": {
             "type": {
-              "type": "string",
-              "default": "image/tiff; application=geotiff; profile=cloud-optimized"
+              "type": "string"
             },
             "roles": {
               "type": "array",
               "items": {
                 "type": "string"
-              },
-              "default": ["data", "layer"]
+              }
             },
             "title": {
-              "type": "string",
-              "default": "Default COG Layer"
+              "type": "string"
             },
             "description": {
-              "type": "string",
-              "default": "Cloud optimized default layer to display on map"
+              "type": "string"
             }
           }
         }

--- a/__tests__/playwright/CreateDatasetPage.test.tsx
+++ b/__tests__/playwright/CreateDatasetPage.test.tsx
@@ -331,7 +331,6 @@ test.describe('Create Dataset Page', () => {
         'sample_files',
         'data_type',
         'providers',
-        'item_assets',
         'renders',
       ];
 

--- a/components/DatasetIngestionForm.tsx
+++ b/components/DatasetIngestionForm.tsx
@@ -88,6 +88,50 @@ function DatasetIngestionForm({
     [key: string]: any;
   } | null>(null);
 
+  // --- Set initial "default" data for new forms ---
+  useEffect(() => {
+    if (!isEditMode && (!formData || Object.keys(formData).length === 0)) {
+      setFormData((prevFormData) => ({
+        ...prevFormData,
+        // Manually set "default" values here
+        license: 'CC0-1.0',
+        stac_version: '1.0.0',
+        spatial_extent: {
+          xmin: -180,
+          ymin: -90,
+          xmax: 180,
+          ymax: 90,
+        },
+        stac_extensions: [
+          'https://stac-extensions.github.io/render/v1.0.0/schema.json',
+          'https://stac-extensions.github.io/item-assets/v1.0.0/schema.json',
+        ],
+        item_assets: {
+          cog_default: {
+            type: 'image/tiff; application=geotiff; profile=cloud-optimized',
+            roles: ['data', 'layer'],
+            title: 'Default COG Layer',
+            description: 'Cloud optimized default layer to display on map',
+          },
+        },
+        providers: [
+          {
+            name: 'NASA VEDA',
+            roles: ['host'],
+            url: 'https://www.earthdata.nasa.gov/dashboard/',
+          },
+        ],
+        assets: {
+          thumbnail: {
+            title: 'Thumbnail',
+            type: 'image/jpeg',
+            roles: ['thumbnail'],
+          },
+        },
+      }));
+    }
+  }, [isEditMode, formData, setFormData]);
+
   useEffect(() => {
     if (defaultTemporalExtent) {
       setFormData((prevFormData: FormData | undefined) => {


### PR DESCRIPTION
In #101 I disabled the requirements for `cog_defaults` however if a user pastes in a config on the json editor without any values, the RJSF form automatically was re-inserting the default values. This sets those values by default on component load, but then allows the user to delete the values.