### PR TITLE
add tooltip to description and thumbnail description

### DIFF
--- a/FormSchemas/collections/uischema.json
+++ b/FormSchemas/collections/uischema.json
@@ -62,5 +62,10 @@
       "size": "large",
       "block": "true"
     }
+  },
+  "description": {
+    "ui:options": {
+      "description": "This describes the STAC collection."
+    }
   }
 }

--- a/FormSchemas/datasets/uischema.json
+++ b/FormSchemas/datasets/uischema.json
@@ -147,7 +147,8 @@
       "description": {
         "ui:widget": "textarea",
         "ui:options": {
-          "rows": 8
+          "rows": 8,
+          "description": "This describes the source of the thumbnail image."
         }
       }
     }
@@ -155,7 +156,8 @@
   "description": {
     "ui:widget": "textarea",
     "ui:options": {
-      "rows": 8
+      "rows": 8,
+      "description": "This describes the dataset."
     }
   },
   "renders": {


### PR DESCRIPTION
closes [#106  - add placeholder to collection/dataset description and thumbnail description inputs](https://github.com/NASA-IMPACT/veda-ingest-ui/issues/106)

this adds some clarity to the intent of the content in the thumbnail description and the top level description fields.

<img width="45%" height="387" alt="STAC Collection description" src="https://github.com/user-attachments/assets/861e5967-e488-4a3a-847f-e781911e7f68" />
<img width="45%" height="446" alt="Dataset Description" src="https://github.com/user-attachments/assets/9ebd3953-3db3-4f46-962f-9dc7d0db109b" />

<img width="833" height="491" alt="thumbnail description" src="https://github.com/user-attachments/assets/81dcbe4c-3ca1-4acd-8d68-28d76b8b31f8" />


