### PR TITLE
handle dashboard:time_duration and improve json editor modal

### DIFF
--- a/FormSchemas/collections/collectionSchema.json
+++ b/FormSchemas/collections/collectionSchema.json
@@ -220,6 +220,19 @@
           }
         }
       }
+    },
+    "dashboard:is_periodic": {
+      "type": "boolean",
+      "title": "Is Periodic?"
+    },
+    "dashboard:time_density": {
+      "type": "string",
+      "title": "Time Density"
+    },
+    "dashboard:time_interval": {
+      "type": "string",
+      "format": "duration",
+      "title": "Time Interval"
     }
   }
 }

--- a/FormSchemas/collections/uischema.json
+++ b/FormSchemas/collections/uischema.json
@@ -1,11 +1,16 @@
 {
   "ui:grid": [
     {
-      "id": 6,
-      "title": 6,
-      "type": 4,
+      "id": 8,
+      "title": 12,
+      "type": 4
+    },
+    {
       "stac_version": 4,
-      "license": 4
+      "license": 6,
+      "dashboard:is_periodic": 2,
+      "dashboard:time_density": 6,
+      "dashboard:time_interval": 6
     },
     {
       "description": 12,
@@ -64,8 +69,10 @@
     }
   },
   "description": {
+    "ui:widget": "textarea",
     "ui:options": {
-      "description": "This describes the STAC collection."
+      "description": "This describes the STAC collection.",
+      "rows": 8
     }
   }
 }

--- a/FormSchemas/datasets/datasetSchema.json
+++ b/FormSchemas/datasets/datasetSchema.json
@@ -44,6 +44,11 @@
       "type": "string",
       "title": "Time Density"
     },
+    "dashboard:time_interval": {
+      "type": "string",
+      "format": "duration",
+      "title": "Time Interval"
+    },
     "links": {
       "title": "Links",
       "type": "array",

--- a/FormSchemas/datasets/uischema.json
+++ b/FormSchemas/datasets/uischema.json
@@ -1,13 +1,16 @@
 {
   "ui:grid": [
     {
-      "collection": 4,
-      "title": 6,
-      "license": 2,
-      "dashboard:is_periodic": 3,
-      "dashboard:time_density": 3,
-      "data_type": 3,
-      "stac_version": 3
+      "collection": 8,
+      "title": 12,
+      "data_type": 4
+    },
+    {
+      "stac_version": 4,
+      "license": 6,
+      "dashboard:is_periodic": 2,
+      "dashboard:time_density": 6,
+      "dashboard:time_interval": 6
     },
     {
       "description": 12,


### PR DESCRIPTION
This updates the Collection schema to allow the 3 different dashboard prefixes (dashboard:time_density,  dashboard:time_interval , and  dashboard:is_periodic)

It also adds the `dashboard:time_interval ` to the datasets schema.

Finally, it updates the modal for users that omit the `dashboard:` prefix to make it clearer the recommended change

<img width="819" height="499" alt="Screenshot 2025-08-05 at 8 36 46 PM" src="https://github.com/user-attachments/assets/12ed4425-9e81-46d1-8c53-3b27ac735cfe" />
<img width="1517" height="352" alt="Screenshot 2025-08-05 at 8 03 02 PM" src="https://github.com/user-attachments/assets/000c5b1d-54cf-4545-ba45-b719d14f932e" />
<img width="1508" height="539" alt="Screenshot 2025-08-05 at 8 38 11 PM" src="https://github.com/user-attachments/assets/878f75cc-4fcd-45e4-bf5b-ef60eb3f5a58" />
