### PR TITLE
Allow users to add optional additional notes for maintainers to the PR body

### DIFF
--- a/__tests__/api/CreateIngestRoute.test.ts
+++ b/__tests__/api/CreateIngestRoute.test.ts
@@ -12,6 +12,7 @@ describe('POST /api/create-ingest', () => {
     const mockBody = {
       data: { collection: 'Test Collection' },
       ingestionType: 'collection',
+      userComment: undefined,
     };
     const mockRequest = {
       json: vi.fn().mockResolvedValue(mockBody),
@@ -24,7 +25,8 @@ describe('POST /api/create-ingest', () => {
 
     expect(CreatePR).toHaveBeenCalledWith(
       mockBody.data,
-      mockBody.ingestionType
+      mockBody.ingestionType,
+      mockBody.userComment
     );
     expect(jsonResponse).toEqual({ githubURL: 'https://github.com/test/pr' });
     expect(response.status).toBe(200);

--- a/__tests__/components/CreationFormManager.test.tsx
+++ b/__tests__/components/CreationFormManager.test.tsx
@@ -1,4 +1,13 @@
-import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest';
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  Mock,
+  beforeAll,
+} from 'vitest';
 import {
   render,
   screen,
@@ -9,33 +18,46 @@ import {
 import CreationFormManager from '@/components/CreationFormManager';
 import React from 'react';
 
+// --- JSDOM Workaround for Ant Design ---
+beforeAll(() => {
+  Object.defineProperty(window, 'getComputedStyle', {
+    value: (elt: { style: any }) => {
+      // The 'elt' parameter is the DOM element being checked.
+      // We can read its actual inline styles.
+      const style = elt.style;
+      return {
+        getPropertyValue: (prop: string | number) => {
+          // Return the property from the element's inline style
+          // This will correctly return 'none' when antd hides the modal.
+          return style[prop] || '';
+        },
+      };
+    },
+  });
+});
+
 // Mock child components to isolate the manager's logic
 vi.mock('@/components/DatasetIngestionForm', () => ({
-  default: ({ onSubmit, children }: any) => (
+  default: ({ onSubmit }: any) => (
     <form
       data-testid="dataset-ingestion-form"
       onSubmit={(e) => {
         e.preventDefault();
         onSubmit({ collection: 'Test Dataset' });
       }}
-    >
-      <button onClick={() => onSubmit(undefined)}>Submit No Data</button>
-      {children}
-    </form>
+    ></form>
   ),
 }));
 
 vi.mock('@/components/CollectionIngestionForm', () => ({
-  default: ({ onSubmit, children }: any) => (
+  default: ({ onSubmit }: any) => (
     <form
       data-testid="collection-ingestion-form"
       onSubmit={(e) => {
         e.preventDefault();
         onSubmit({ collection: 'Test Collection', id: 'test-collection-id' });
       }}
-    >
-      {children}
-    </form>
+    ></form>
   ),
 }));
 
@@ -57,29 +79,31 @@ describe('CreationFormManager', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Since Antd Modals are rendered in a portal, we need a container in the body
+    const portalRoot = document.createElement('div');
+    portalRoot.setAttribute('id', 'portal-root');
+    document.body.appendChild(portalRoot);
   });
 
   afterEach(() => {
     cleanup();
+    const portalRoot = document.getElementById('portal-root');
+    if (portalRoot) {
+      document.body.removeChild(portalRoot);
+    }
   });
 
   it('renders DatasetIngestionForm when formType is "dataset"', () => {
     render(<CreationFormManager {...defaultProps} formType="dataset" />);
     expect(screen.getByTestId('dataset-ingestion-form')).toBeInTheDocument();
-    expect(
-      screen.queryByTestId('collection-ingestion-form')
-    ).not.toBeInTheDocument();
   });
 
   it('renders CollectionIngestionForm when formType is "collection"', () => {
     render(<CreationFormManager {...defaultProps} formType="collection" />);
     expect(screen.getByTestId('collection-ingestion-form')).toBeInTheDocument();
-    expect(
-      screen.queryByTestId('dataset-ingestion-form')
-    ).not.toBeInTheDocument();
   });
 
-  it('handles successful dataset form submission', async () => {
+  it('handles successful submission with a comment via the modal', async () => {
     (fetch as Mock).mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({ githubURL: 'http://github.com/pr/1' }),
@@ -89,6 +113,21 @@ describe('CreationFormManager', () => {
 
     const form = screen.getByTestId('dataset-ingestion-form');
     fireEvent.submit(form);
+
+    const modalTitle = await screen.findByText(
+      'Add an Optional Note for Maintainers'
+    );
+    expect(modalTitle).toBeInTheDocument();
+
+    const commentInput = screen.getByPlaceholderText(
+      /This is a new data type/i
+    );
+    fireEvent.change(commentInput, { target: { value: 'This is a test' } });
+
+    const submitButton = screen.getByRole('button', {
+      name: /Continue & Submit/i,
+    });
+    fireEvent.click(submitButton);
 
     await waitFor(() => {
       expect(mockSetStatus).toHaveBeenCalledWith('loadingGithub');
@@ -101,6 +140,7 @@ describe('CreationFormManager', () => {
         body: JSON.stringify({
           data: { collection: 'Test Dataset' },
           ingestionType: 'dataset',
+          userComment: 'This is a test',
         }),
         headers: { 'Content-Type': 'application/json' },
       });
@@ -111,38 +151,49 @@ describe('CreationFormManager', () => {
     });
   });
 
-  it('handles successful collection form submission', async () => {
+  it('handles submission with an empty comment', async () => {
     (fetch as Mock).mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({ githubURL: 'http://github.com/pr/2' }),
+      json: () => Promise.resolve({ githubURL: 'http://github.com/pr/1' }),
     });
 
-    render(<CreationFormManager {...defaultProps} formType="collection" />);
-    const form = screen.getByTestId('collection-ingestion-form');
-    fireEvent.submit(form);
+    render(<CreationFormManager {...defaultProps} formType="dataset" />);
+    fireEvent.submit(screen.getByTestId('dataset-ingestion-form'));
 
-    await waitFor(() => {
-      expect(mockSetStatus).toHaveBeenCalledWith('loadingGithub');
-      expect(mockSetCollectionName).toHaveBeenCalledWith('Test Collection');
+    const submitButton = await screen.findByRole('button', {
+      name: /Continue & Submit/i,
     });
+    fireEvent.click(submitButton);
 
     await waitFor(() => {
-      expect(fetch).toHaveBeenCalledWith('api/create-ingest', {
-        method: 'POST',
-        body: JSON.stringify({
-          data: { collection: 'Test Collection', id: 'test-collection-id' },
-          ingestionType: 'collection',
-        }),
-        headers: { 'Content-Type': 'application/json' },
-      });
-      expect(mockSetPullRequestUrl).toHaveBeenCalledWith(
-        'http://github.com/pr/2'
-      );
-      expect(mockSetStatus).toHaveBeenCalledWith('success');
+      const payload = JSON.parse((fetch as Mock).mock.calls[0][1].body);
+      expect(payload.userComment).toBe('');
     });
   });
 
-  it('handles failed form submission', async () => {
+  it('cancels submission when modal is closed', async () => {
+    render(<CreationFormManager {...defaultProps} formType="dataset" />);
+
+    const form = screen.getByTestId('dataset-ingestion-form');
+    fireEvent.submit(form);
+    await screen.findByText('Add an Optional Note for Maintainers');
+
+    const cancelButton = screen.getByRole('button', { name: /Cancel/i });
+    fireEvent.click(cancelButton);
+
+    // Assert the modal is gone
+    await waitFor(() => {
+      expect(
+        screen.queryByText('Add an Optional Note for Maintainers')
+      ).not.toBeInTheDocument();
+    });
+
+    // Assert that fetch was never called
+    expect(fetch).not.toHaveBeenCalled();
+    expect(mockSetStatus).not.toHaveBeenCalled();
+  });
+
+  it('handles failed form submission after modal confirmation', async () => {
     (fetch as Mock).mockResolvedValue({
       ok: false,
       text: () => Promise.resolve('API Error'),
@@ -150,14 +201,15 @@ describe('CreationFormManager', () => {
 
     render(<CreationFormManager {...defaultProps} formType="dataset" />);
 
-    const form = screen.getByTestId('dataset-ingestion-form');
-    fireEvent.submit(form);
+    fireEvent.submit(screen.getByTestId('dataset-ingestion-form'));
+    const submitButton = await screen.findByRole('button', {
+      name: /Continue & Submit/i,
+    });
+    fireEvent.click(submitButton);
 
+    // Assert failure state is set
     await waitFor(() => {
       expect(mockSetStatus).toHaveBeenCalledWith('loadingGithub');
-    });
-
-    await waitFor(() => {
       expect(mockSetApiErrorMessage).toHaveBeenCalledWith('API Error');
       expect(mockSetStatus).toHaveBeenCalledWith('error');
     });
@@ -166,7 +218,6 @@ describe('CreationFormManager', () => {
   it('renders an error message for an invalid formType', () => {
     // @ts-expect-error - Intentionally passing invalid prop for testing
     render(<CreationFormManager {...defaultProps} formType="invalid-type" />);
-
     expect(
       screen.getByText(
         'Invalid formType specified. Please use dataset or collection.'

--- a/__tests__/playwright/CreateCollectionPage.test.tsx
+++ b/__tests__/playwright/CreateCollectionPage.test.tsx
@@ -125,15 +125,25 @@ test.describe('Create Collection Page', () => {
   test('Create Collection request submitted with pasted JSON', async ({
     page,
   }, testInfo) => {
+    const userComment = 'This comment was entered in the VEDA Ingest UI';
     // Intercept the POST request to validate its payload
     await page.route('**/create-dataset', async (route, request) => {
       if (request.method() === 'POST') {
         const postData = request.postDataJSON();
 
-        expect(postData.ingestionType).toBe('collection');
-        expect(postData.data).toEqual(
-          expect.objectContaining(requiredCollectionConfig)
-        );
+        expect(
+          postData.ingestionType,
+          'Ingestion Type is included in POST data'
+        ).toBe('collection');
+        expect(
+          postData.data,
+          `Collection cofig data is included in POST data`
+        ).toEqual(expect.objectContaining(requiredCollectionConfig));
+
+        expect(
+          postData.userComment,
+          'user comment is included in POST data'
+        ).toBe(userComment);
 
         await route.fulfill({
           status: 200,
@@ -183,7 +193,8 @@ test.describe('Create Collection Page', () => {
     await test.step('submit form and validate that POST body values match pasted config values', async () => {
       await page.getByRole('button', { name: /submit/i }).click();
     });
-    await test.step('continue without adding a comment', async () => {
+    await test.step('add comment and continue', async () => {
+      await page.getByTestId('user-comment-textarea').fill(userComment);
       await page.getByRole('button', { name: /continue & submit/i }).click();
     });
 

--- a/__tests__/playwright/CreateCollectionPage.test.tsx
+++ b/__tests__/playwright/CreateCollectionPage.test.tsx
@@ -99,12 +99,16 @@ test.describe('Create Collection Page', () => {
       await page.getByRole('button', { name: /submit/i }).click();
     });
 
+    await test.step('continue without adding a comment', async () => {
+      await page.getByRole('button', { name: /continue & submit/i }).click();
+    });
+
     await expect(
-      page.getByRole('dialog', { name: /Collection Submitted/i })
+      page.getByRole('dialog', { name: /Ingestion Request Submitted/i })
     ).toBeVisible();
 
     const githubLink = page
-      .getByRole('dialog', { name: /Collection Submitted/i })
+      .getByRole('dialog', { name: /Ingestion Request Submitted/i })
       .getByRole('link', { name: /github/i });
     await expect(githubLink).toBeVisible();
 
@@ -179,9 +183,12 @@ test.describe('Create Collection Page', () => {
     await test.step('submit form and validate that POST body values match pasted config values', async () => {
       await page.getByRole('button', { name: /submit/i }).click();
     });
+    await test.step('continue without adding a comment', async () => {
+      await page.getByRole('button', { name: /continue & submit/i }).click();
+    });
 
     await expect(
-      page.getByRole('dialog', { name: /Collection Submitted/i })
+      page.getByRole('dialog', { name: /Ingestion Request Submitted/i })
     ).toBeVisible();
   });
 
@@ -271,6 +278,10 @@ test.describe('Create Collection Page', () => {
 
     await test.step('submit form and validate that POST body includes the extra field', async () => {
       await page.getByRole('button', { name: /submit/i }).click();
+    });
+
+    await test.step('continue without adding a comment', async () => {
+      await page.getByRole('button', { name: /continue & submit/i }).click();
     });
   });
 
@@ -389,6 +400,11 @@ test.describe('Create Collection Page', () => {
     await test.step('submit completed form', async () => {
       await page.getByRole('button', { name: /submit/i }).click();
     });
+
+    await test.step('continue without adding a comment', async () => {
+      await page.getByRole('button', { name: /continue & submit/i }).click();
+    });
+
     await expect(
       page.getByRole('dialog', { name: /Collection Name Exists/i })
     ).toBeVisible();
@@ -433,6 +449,11 @@ test.describe('Create Collection Page', () => {
     await test.step('submit completed form', async () => {
       await page.getByRole('button', { name: /submit/i }).click();
     });
+
+    await test.step('continue without adding a comment', async () => {
+      await page.getByRole('button', { name: /continue & submit/i }).click();
+    });
+
     await expect(
       page.getByRole('dialog', { name: /Something Went Wrong/i })
     ).toBeVisible();

--- a/__tests__/playwright/CreateDatasetPage.test.tsx
+++ b/__tests__/playwright/CreateDatasetPage.test.tsx
@@ -72,9 +72,6 @@ const requiredConfig = {
 
 const MOCK_GITHUB_URL = 'https://github.com/nasa-veda/veda-data/pull/12345';
 
-const DATASET_SUCCESS_DIALOG_TITLE = /Ingest Submitted/i;
-const COLLECTION_SUCCESS_DIALOG_TITLE = /Collection Submitted/i;
-
 test.describe('Create Dataset Page', () => {
   test('Create Dataset request displays github link to PR', async ({
     page,
@@ -106,13 +103,15 @@ test.describe('Create Dataset Page', () => {
       await page.getByRole('button', { name: /submit/i }).click();
     });
 
+    await test.step('continue without adding a comment', async () => {
+      await page.getByRole('button', { name: /continue & submit/i }).click();
+    });
+
     const successDialog = page.getByRole('dialog', {
-      name: DATASET_SUCCESS_DIALOG_TITLE,
+      name: /Ingestion Request Submitted/i,
     });
-    const legacyDialog = page.getByRole('dialog', {
-      name: COLLECTION_SUCCESS_DIALOG_TITLE,
-    });
-    await expect(successDialog.or(legacyDialog)).toBeVisible();
+
+    await expect(successDialog).toBeVisible();
 
     const githubLink = page.getByRole('link', { name: /github/i }).first();
     await expect(githubLink).toBeVisible();
@@ -200,13 +199,15 @@ test.describe('Create Dataset Page', () => {
       await page.getByRole('button', { name: /submit/i }).click();
     });
 
+    await test.step('continue without adding a comment', async () => {
+      await page.getByRole('button', { name: /continue & submit/i }).click();
+    });
+
     const successDialog = page.getByRole('dialog', {
-      name: DATASET_SUCCESS_DIALOG_TITLE,
+      name: /Ingestion Request Submitted/i,
     });
-    const legacyDialog = page.getByRole('dialog', {
-      name: COLLECTION_SUCCESS_DIALOG_TITLE,
-    });
-    await expect(successDialog.or(legacyDialog)).toBeVisible();
+
+    await expect(successDialog).toBeVisible();
   });
 
   test('Create Dataset allows extra fields with toggle enabled', async ({
@@ -289,6 +290,10 @@ test.describe('Create Dataset Page', () => {
 
     await test.step('submit form and validate that POST body values match pasted config values including extra field', async () => {
       await page.getByRole('button', { name: /submit/i }).click();
+    });
+
+    await test.step('continue without adding a comment', async () => {
+      await page.getByRole('button', { name: /continue & submit/i }).click();
     });
   });
 
@@ -412,6 +417,11 @@ test.describe('Create Dataset Page', () => {
     await test.step('submit completed form', async () => {
       await page.getByRole('button', { name: /submit/i }).click();
     });
+
+    await test.step('continue without adding a comment', async () => {
+      await page.getByRole('button', { name: /continue & submit/i }).click();
+    });
+
     await expect(
       page.getByRole('dialog', { name: /Collection Name Exists/i })
     ).toBeVisible();
@@ -455,6 +465,11 @@ test.describe('Create Dataset Page', () => {
     await test.step('submit completed form', async () => {
       await page.getByRole('button', { name: /submit/i }).click();
     });
+
+    await test.step('continue without adding a comment', async () => {
+      await page.getByRole('button', { name: /continue & submit/i }).click();
+    });
+
     await expect(
       page.getByRole('dialog', { name: /Something Went Wrong/i })
     ).toBeVisible();

--- a/__tests__/playwright/ExtensionsAndAdditionalProperties.test.tsx
+++ b/__tests__/playwright/ExtensionsAndAdditionalProperties.test.tsx
@@ -130,8 +130,13 @@ test.describe('Extensions and Additional Properties', () => {
       });
 
       await page.getByRole('button', { name: /submit/i }).click();
+
+      await test.step('continue without adding a comment', async () => {
+        await page.getByRole('button', { name: /continue & submit/i }).click();
+      });
+
       await expect(
-        page.getByRole('dialog', { name: /Collection Submitted/i })
+        page.getByRole('dialog', { name: /Ingestion Request Submitted/i })
       ).toBeVisible();
     });
   });

--- a/app/api/create-ingest/route.ts
+++ b/app/api/create-ingest/route.ts
@@ -6,7 +6,7 @@ type AllowedIngestionType = 'dataset' | 'collection';
 
 export async function POST(request: NextRequest) {
   try {
-    const { data, ingestionType } = await request.json();
+    const { data, ingestionType, userComment } = await request.json();
 
     if (!data) {
       return NextResponse.json(
@@ -27,7 +27,11 @@ export async function POST(request: NextRequest) {
 
     const validatedIngestionType: AllowedIngestionType = ingestionType;
 
-    const githubResponse = await CreatePR(data, validatedIngestionType);
+    const githubResponse = await CreatePR(
+      data,
+      validatedIngestionType,
+      userComment
+    );
 
     return NextResponse.json({ githubURL: githubResponse });
   } catch (error) {

--- a/components/CreationFormManager.tsx
+++ b/components/CreationFormManager.tsx
@@ -144,6 +144,7 @@ const CreationFormManager: React.FC<CreationFormManagerProps> = ({
           value={userComment}
           onChange={(e) => setUserComment(e.target.value)}
           placeholder="e.g., This is a new data type."
+          data-testid="user-comment-textarea"
         />
       </Modal>
     </>

--- a/components/CreationFormManager.tsx
+++ b/components/CreationFormManager.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import React, { useState } from 'react';
-import { Card, Typography, Alert } from 'antd';
+import { Card, Typography, Alert, Modal, Input } from 'antd';
 import { Status } from '@/types/global';
 import DatasetIngestionForm from '@/components/DatasetIngestionForm';
 import CollectionIngestionForm from '@/components/CollectionIngestionForm';
 
 const { Title } = Typography;
+const { TextArea } = Input;
 
 interface CreationFormManagerProps {
   formType: 'dataset' | 'collection';
@@ -24,20 +25,38 @@ const CreationFormManager: React.FC<CreationFormManagerProps> = ({
   setPullRequestUrl,
 }) => {
   const [formData, setFormData] = useState<Record<string, unknown>>({});
+  const [isModalVisible, setIsModalVisible] = useState(false);
+  const [userComment, setUserComment] = useState('');
+  const [stagedFormData, setStagedFormData] = useState<Record<
+    string,
+    unknown
+  > | null>(null);
 
-  const onFormDataSubmit = (data?: Record<string, unknown>) => {
+  const handleFormSubmit = (data?: Record<string, unknown>) => {
     if (!data) {
       console.error('No form data provided.');
       return;
     }
+    setStagedFormData(data);
+    setIsModalVisible(true);
+  };
 
+  const handleFinalSubmit = () => {
+    if (!stagedFormData) {
+      console.error('No staged form data available for submission.');
+      setIsModalVisible(false);
+      return;
+    }
+
+    setIsModalVisible(false);
     setStatus('loadingGithub');
-    setCollectionName(data.collection as string);
+    setCollectionName(stagedFormData.collection as string);
 
     const url = 'api/create-ingest';
     const payload = {
-      data: data,
+      data: stagedFormData,
       ingestionType: formType,
+      userComment: userComment,
     };
 
     const requestOptions = {
@@ -62,39 +81,72 @@ const CreationFormManager: React.FC<CreationFormManagerProps> = ({
       .catch((error) => {
         console.error(error);
         setStatus('error');
+      })
+      .finally(() => {
+        setStagedFormData(null);
+        setUserComment('');
       });
+  };
+
+  const handleCancel = () => {
+    setIsModalVisible(false);
+    setStagedFormData(null);
+    setUserComment('');
   };
 
   const childFormProps = {
     formData,
     setFormData,
-    onSubmit: onFormDataSubmit,
-    isEditMode: false, // Explicitly false for creation
+    onSubmit: handleFormSubmit,
+    isEditMode: false,
   };
 
   const title = `Create New ${formType.charAt(0).toUpperCase() + formType.slice(1)}`;
 
   return (
-    <Card>
-      <Title level={2} style={{ marginBottom: '24px' }}>
-        {title}
-      </Title>
+    <>
+      <Card>
+        <Title level={2} style={{ marginBottom: '24px' }}>
+          {title}
+        </Title>
 
-      {formType === 'dataset' ? (
-        <DatasetIngestionForm
-          {...childFormProps}
-          defaultTemporalExtent={true}
+        {formType === 'dataset' ? (
+          <DatasetIngestionForm
+            {...childFormProps}
+            defaultTemporalExtent={true}
+          />
+        ) : formType === 'collection' ? (
+          <CollectionIngestionForm {...childFormProps} />
+        ) : (
+          <Alert
+            message="Invalid formType specified. Please use dataset or collection."
+            type="error"
+            showIcon
+          />
+        )}
+      </Card>
+
+      <Modal
+        title="Add an Optional Note for Maintainers"
+        open={isModalVisible}
+        onOk={handleFinalSubmit}
+        onCancel={handleCancel}
+        okText="Continue & Submit"
+        cancelText="Cancel"
+        destroyOnHidden={true}
+      >
+        <p style={{ marginBottom: 8 }}>
+          You can add additional information for the Data Services Team to help
+          with this ingest. This message is optional.
+        </p>
+        <TextArea
+          rows={4}
+          value={userComment}
+          onChange={(e) => setUserComment(e.target.value)}
+          placeholder="e.g., This is a new data type."
         />
-      ) : formType === 'collection' ? (
-        <CollectionIngestionForm {...childFormProps} />
-      ) : (
-        <Alert
-          message="Invalid formType specified. Please use dataset or collection."
-          type="error"
-          showIcon
-        />
-      )}
-    </Card>
+      </Modal>
+    </>
   );
 };
 

--- a/components/SuccessModal.tsx
+++ b/components/SuccessModal.tsx
@@ -20,7 +20,9 @@ type SuccessModalProps =
 
 export default function SuccessModal(props: SuccessModalProps) {
   const title =
-    props.type === 'edit' ? 'Collection Updated' : 'Collection Submitted';
+    props.type === 'edit'
+      ? 'Ingestion Request Updated'
+      : 'Ingestion Request Submitted';
 
   const content =
     props.type === 'edit' ? (

--- a/utils/githubUtils/CreatePR.ts
+++ b/utils/githubUtils/CreatePR.ts
@@ -15,7 +15,8 @@ type IngestionType = 'dataset' | 'collection';
 
 const CreatePR = async (
   data: Data,
-  ingestionType: IngestionType
+  ingestionType: IngestionType,
+  userComment?: string
 ): Promise<string> => {
   const targetBranch = process.env.TARGET_BRANCH || 'main';
   const owner = process.env.OWNER;
@@ -107,6 +108,7 @@ const CreatePR = async (
       head: branchName,
       base: targetBranch,
       title: `Ingest Request for ${fileNameSource}`,
+      body: userComment || '',
     });
 
     return pr.data.html_url;


### PR DESCRIPTION
closes #112

This adds an additional modal to the creation form submission flow.  If a user enters text, it is placed in the PR body.  The comment is optional and is just a text area field for now, but Markdown formatting does get passed to the github client



<img width="1091" height="473" alt="Additional Notes Modal" src="https://github.com/user-attachments/assets/23633a1b-ec90-4220-a0a2-fdfcc0854e76" />

## example coment on PR

<img width="800" height="310" alt="Screenshot 2025-08-06 at 3 42 31 PM" src="https://github.com/user-attachments/assets/81544503-be3c-41c0-9245-bc0b31a8197e" />

