### PR TITLE
add tenant property to JSON Schema

### DIFF
--- a/FormSchemas/collections/collectionSchema.json
+++ b/FormSchemas/collections/collectionSchema.json
@@ -235,6 +235,15 @@
       "type": "string",
       "format": "duration",
       "title": "Time Interval"
+    },
+    "tenant": {
+      "type": "array",
+      "title": "Tenants",
+      "description": "Optional list of tenants allowed to access this item.",
+      "items": {
+        "type": "string"
+      },
+      "uniqueItems": true
     }
   }
 }

--- a/FormSchemas/datasets/datasetSchema.json
+++ b/FormSchemas/datasets/datasetSchema.json
@@ -317,6 +317,15 @@
           }
         }
       }
+    },
+    "tenant": {
+      "type": "array",
+      "title": "Tenants",
+      "description": "Optional list of tenants allowed to access this item.",
+      "items": {
+        "type": "string"
+      },
+      "uniqueItems": true
     }
   }
 }


### PR DESCRIPTION
this is a baby step to help support phase one as documented in [[DS 25.4 Multi-Tenancy] Add Multi-Tenant Support to VEDA Ingest UI](https://github.com/NASA-IMPACT/veda-ingest-ui/issues/123)https://github.com/NASA-IMPACT/veda-ingest-ui/issues/123 and https://github.com/NASA-IMPACT/veda-architecture/issues/630

This PR will add the "tenants" property to both collections and dataset json schemas. It doesn't add it to the UI schema. This will allow an array of strings for a key called `"tenant"` in the JSON Editor without the need for overriding the rest of the validation. I won't add the new `tenant` key to the UI Config yet. This will prevent anything new from being displayed on the form tab.