### PR TITLE
Fix/use dyanmic tenant filter field

### DIFF
--- a/FormSchemas/collections/collectionSchema.json
+++ b/FormSchemas/collections/collectionSchema.json
@@ -48,12 +48,17 @@
     "extent": {
       "title": "Extents",
       "type": "object",
-      "required": ["spatial", "temporal"],
+      "required": [
+        "spatial",
+        "temporal"
+      ],
       "properties": {
         "spatial": {
           "title": "Spatial extent object",
           "type": "object",
-          "required": ["bbox"],
+          "required": [
+            "bbox"
+          ],
           "properties": {
             "bbox": {
               "title": "Spatial extents",
@@ -74,7 +79,9 @@
         "temporal": {
           "title": "Temporal extent object",
           "type": "object",
-          "required": ["interval"],
+          "required": [
+            "interval"
+          ],
           "properties": {
             "interval": {
               "title": "Temporal extents",
@@ -86,7 +93,10 @@
                 "minItems": 2,
                 "maxItems": 2,
                 "items": {
-                  "type": ["string", "null"],
+                  "type": [
+                    "string",
+                    "null"
+                  ],
                   "pattern": "(\\+00:00|\\+00|Z)$"
                 }
               }
@@ -100,7 +110,10 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["rel", "href"],
+        "required": [
+          "rel",
+          "href"
+        ],
         "properties": {
           "href": {
             "title": "Link reference",
@@ -134,15 +147,24 @@
           {
             "title": "Range",
             "type": "object",
-            "required": ["minimum", "maximum"],
+            "required": [
+              "minimum",
+              "maximum"
+            ],
             "properties": {
               "minimum": {
                 "title": "Minimum value",
-                "type": ["number", "string"]
+                "type": [
+                  "number",
+                  "string"
+                ]
               },
               "maximum": {
                 "title": "Maximum value",
-                "type": ["number", "string"]
+                "type": [
+                  "number",
+                  "string"
+                ]
               }
             }
           },
@@ -162,7 +184,9 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "properties": {
           "name": {
             "title": "Organization name",
@@ -177,7 +201,12 @@
             "type": "array",
             "items": {
               "type": "string",
-              "enum": ["producer", "licensor", "processor", "host"]
+              "enum": [
+                "producer",
+                "licensor",
+                "processor",
+                "host"
+              ]
             }
           },
           "url": {
@@ -192,7 +221,9 @@
       "type": "object",
       "additionalProperties": {
         "type": "object",
-        "required": ["href"],
+        "required": [
+          "href"
+        ],
         "properties": {
           "href": {
             "title": "Asset reference",
@@ -227,17 +258,17 @@
     },
     "dashboard:time_density": {
       "type": "string",
-      "enum": ["day", "month", "year"],
+      "enum": [
+        "day",
+        "month",
+        "year"
+      ],
       "title": "Time Density"
     },
     "dashboard:time_interval": {
       "type": "string",
       "format": "duration",
       "title": "Time Interval"
-    },
-    "tenant": {
-      "type": "string",
-      "title": "Tenants"
     }
   }
 }

--- a/FormSchemas/collections/uischema.json
+++ b/FormSchemas/collections/uischema.json
@@ -1,9 +1,6 @@
 {
   "ui:grid": [
     {
-      "tenant": 24
-    },
-    {
       "id": 8,
       "title": 16
     },
@@ -77,9 +74,5 @@
       "description": "This describes the STAC collection.",
       "rows": 8
     }
-  },
-  "tenant": {
-    "classNames": "tenants-field",
-    "ui:help": "Optional tenant allowed to access this item."
   }
 }

--- a/FormSchemas/datasets/datasetSchema.json
+++ b/FormSchemas/datasets/datasetSchema.json
@@ -42,7 +42,11 @@
     },
     "dashboard:time_density": {
       "type": "string",
-      "enum": ["day", "month", "year"],
+      "enum": [
+        "day",
+        "month",
+        "year"
+      ],
       "title": "Time Density"
     },
     "dashboard:time_interval": {
@@ -112,11 +116,17 @@
       "type": "object",
       "properties": {
         "startdate": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "title": "Start Date"
         },
         "enddate": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "title": "End Date"
         }
       }
@@ -129,7 +139,9 @@
         "properties": {
           "discovery": {
             "type": "string",
-            "enum": ["s3"],
+            "enum": [
+              "s3"
+            ],
             "title": "Discovery"
           },
           "prefix": {
@@ -147,7 +159,11 @@
           },
           "datetime_range": {
             "type": "string",
-            "enum": ["day", "month", "year"],
+            "enum": [
+              "day",
+              "month",
+              "year"
+            ],
             "title": "Datetime Range"
           },
           "start_datetime": {
@@ -179,7 +195,10 @@
             "default": false
           }
         },
-        "required": ["prefix", "bucket"]
+        "required": [
+          "prefix",
+          "bucket"
+        ]
       },
       "minItems": 1
     },
@@ -235,7 +254,9 @@
     "renders": {
       "title": "Renders",
       "type": "object",
-      "required": ["dashboard"],
+      "required": [
+        "dashboard"
+      ],
       "properties": {
         "dashboard": {
           "type": "string",
@@ -248,7 +269,9 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "properties": {
           "name": {
             "title": "Organization name",
@@ -264,7 +287,12 @@
             "type": "array",
             "items": {
               "type": "string",
-              "enum": ["producer", "licensor", "processor", "host"]
+              "enum": [
+                "producer",
+                "licensor",
+                "processor",
+                "host"
+              ]
             }
           },
           "url": {
@@ -277,7 +305,9 @@
       "default": [
         {
           "name": "NASA VEDA",
-          "roles": ["host"],
+          "roles": [
+            "host"
+          ],
           "url": "https://www.earthdata.nasa.gov/dashboard/"
         }
       ]
@@ -309,18 +339,22 @@
               }
             }
           },
-          "required": ["title", "description", "href", "type", "roles"],
+          "required": [
+            "title",
+            "description",
+            "href",
+            "type",
+            "roles"
+          ],
           "default": {
             "title": "Thumbnail",
             "type": "image/jpeg",
-            "roles": ["thumbnail"]
+            "roles": [
+              "thumbnail"
+            ]
           }
         }
       }
-    },
-    "tenant": {
-      "type": "string",
-      "title": "Tenants"
     }
   }
 }

--- a/FormSchemas/datasets/uischema.json
+++ b/FormSchemas/datasets/uischema.json
@@ -1,9 +1,6 @@
 {
   "ui:grid": [
     {
-      "tenant": 24
-    },
-    {
       "collection": 8,
       "title": 16
     },
@@ -202,9 +199,5 @@
     "items": {
       "ui:widget": "testableUrl"
     }
-  },
-  "tenant": {
-    "classNames": "tenants-field",
-    "ui:help": "Optional tenant allowed to access this item."
   }
 }

--- a/__mocks__/githubResponse.ts
+++ b/__mocks__/githubResponse.ts
@@ -35,7 +35,7 @@ export const githubResponse = [
       base: { ref: 'main' },
       author_association: 'CONTRIBUTOR',
     },
-    tenant: 'tenant1',
+    'local:tenant': 'tenant1',
   },
   {
     pr: {
@@ -72,7 +72,7 @@ export const githubResponse = [
       base: { ref: 'main' },
       author_association: 'CONTRIBUTOR',
     },
-    tenant: 'tenant3',
+    'local:tenant': 'tenant3',
   },
   {
     // PR #3: Public (no tenants specified)
@@ -135,6 +135,6 @@ export const githubResponse = [
       base: { ref: 'main' },
       author_association: 'CONTRIBUTOR',
     },
-    tenant: 'tenant3',
+    'local:tenant': 'tenant3',
   },
 ];

--- a/__mocks__/handlers.ts
+++ b/__mocks__/handlers.ts
@@ -241,10 +241,9 @@ export const handlers = [
       >;
       filteredResponse.collections = collections.filter((collection) => {
         const collectionTenant =
-          typeof collection.tenant === 'string' ? collection.tenant : '';
-        if (tenant === 'Public') {
-          return !collectionTenant;
-        }
+          typeof collection['local:tenant'] === 'string'
+            ? collection['local:tenant']
+            : undefined;
         return collectionTenant === tenant;
       }) as typeof stacCollectionsResponse.collections;
     }

--- a/__tests__/api/ExistingCollectionByIdRoute.test.ts
+++ b/__tests__/api/ExistingCollectionByIdRoute.test.ts
@@ -56,7 +56,7 @@ const mockCollectionResponse = {
   id: 'test-collection',
   title: 'Test Collection',
   description: 'A test collection',
-  tenant: 'tenant1',
+  'local:tenant': 'tenant1',
 };
 
 describe('GET /api/existing-collection/[collectionId]', () => {
@@ -103,7 +103,7 @@ describe('GET /api/existing-collection/[collectionId]', () => {
       ok: true,
       json: async () => ({
         ...mockCollectionResponse,
-        tenant: 'Public',
+        'local:tenant': 'Public',
       }),
     });
 
@@ -125,7 +125,7 @@ describe('GET /api/existing-collection/[collectionId]', () => {
 
     const data = await response.json();
     expect(data.id).toBe('test-collection');
-    expect(data.tenant).toBe('Public');
+    expect(data['local:tenant']).toBe('Public');
   });
 
   it('successfully fetches collection with no tenant', async () => {
@@ -134,7 +134,7 @@ describe('GET /api/existing-collection/[collectionId]', () => {
       ok: true,
       json: async () => ({
         ...mockCollectionResponse,
-        tenant: '',
+        'local:tenant': '',
       }),
     });
 
@@ -147,7 +147,7 @@ describe('GET /api/existing-collection/[collectionId]', () => {
     expect(validateTenantAccessMock).not.toHaveBeenCalled();
 
     const data = await response.json();
-    expect(data.tenant).toBe('');
+    expect(data['local:tenant']).toBe('');
   });
 
   it('successfully fetches collection when user has tenant access', async () => {
@@ -174,7 +174,7 @@ describe('GET /api/existing-collection/[collectionId]', () => {
 
     const data = await response.json();
     expect(data.id).toBe('test-collection');
-    expect(data.tenant).toBe('tenant1');
+    expect(data['local:tenant']).toBe('tenant1');
   });
 
   it('returns 403 when user does not have tenant access', async () => {
@@ -275,7 +275,7 @@ describe('GET /api/existing-collection/[collectionId]', () => {
       json: async () => ({
         ...mockCollectionResponse,
         id: 'collection with spaces',
-        tenant: 'Public',
+        'local:tenant': 'Public',
       }),
     });
 
@@ -304,8 +304,9 @@ describe('GET /api/existing-collection/[collectionId]', () => {
     mockFetch.mockResolvedValue({
       ok: true,
       json: async () => ({
-        ...mockCollectionResponse,
-        tenant: undefined,
+        id: 'test-collection',
+        title: 'Test Collection',
+        description: 'A test collection',
       }),
     });
 
@@ -318,7 +319,7 @@ describe('GET /api/existing-collection/[collectionId]', () => {
     expect(validateTenantAccessMock).not.toHaveBeenCalled();
 
     const data = await response.json();
-    expect(data.tenant).toBeUndefined();
+    expect(data['local:tenant']).toBeUndefined();
   });
 });
 
@@ -360,7 +361,7 @@ describe('PUT /api/existing-collection/[collectionId]', () => {
       ok: true,
       json: async () => ({
         id: 'test-collection',
-        tenant: 'tenant1',
+        'local:tenant': 'tenant1',
         title: 'Original Title',
       }),
     });
@@ -370,7 +371,7 @@ describe('PUT /api/existing-collection/[collectionId]', () => {
       ok: true,
       json: async () => ({
         ...updateData,
-        tenant: 'tenant1',
+        'local:tenant': 'tenant1',
       }),
     });
 
@@ -519,7 +520,7 @@ describe('PUT /api/existing-collection/[collectionId]', () => {
       ok: true,
       json: async () => ({
         id: 'test-collection',
-        tenant: 'restricted-tenant',
+        'local:tenant': 'restricted-tenant',
       }),
     });
 
@@ -556,7 +557,7 @@ describe('PUT /api/existing-collection/[collectionId]', () => {
       ok: true,
       json: async () => ({
         id: 'public-collection',
-        tenant: 'Public',
+        'local:tenant': 'Public',
       }),
     });
 
@@ -565,7 +566,7 @@ describe('PUT /api/existing-collection/[collectionId]', () => {
       ok: true,
       json: async () => ({
         ...updateData,
-        tenant: 'Public',
+        'local:tenant': 'Public',
       }),
     });
 
@@ -599,7 +600,7 @@ describe('PUT /api/existing-collection/[collectionId]', () => {
       ok: true,
       json: async () => ({
         id: 'test-collection',
-        tenant: 'tenant1',
+        'local:tenant': 'tenant1',
       }),
     });
 

--- a/__tests__/api/ExistingCollectionRoute.test.ts
+++ b/__tests__/api/ExistingCollectionRoute.test.ts
@@ -50,14 +50,14 @@ const mockSession = {
 type StacCollection = {
   id: string;
   title: string;
-  tenant?: string;
+  'local:tenant'?: string;
 };
 
 const mockStacCollectionsResponse: { collections: StacCollection[] } = {
   collections: [
-    { id: 'collection1', title: 'Collection 1', tenant: 'tenant1' },
-    { id: 'collection2', title: 'Collection 2', tenant: 'tenant2' },
-    { id: 'collection3', title: 'Public Collection', tenant: '' },
+    { id: 'collection1', title: 'Collection 1', 'local:tenant': 'tenant1' },
+    { id: 'collection2', title: 'Collection 2', 'local:tenant': 'tenant2' },
+    { id: 'collection3', title: 'Public Collection', 'local:tenant': '' },
     { id: 'collection4', title: 'No Tenant Collection' },
   ],
 };
@@ -126,7 +126,11 @@ describe('GET /api/existing-collection', () => {
       ok: true,
       json: async () => ({
         collections: [
-          { id: 'collection1', title: 'Collection 1', tenant: 'tenant1' },
+          {
+            id: 'collection1',
+            title: 'Collection 1',
+            'local:tenant': 'tenant1',
+          },
         ],
       }),
     });
@@ -166,10 +170,22 @@ describe('GET /api/existing-collection', () => {
       ok: true,
       json: async () => ({
         collections: [
-          { id: 'collection1', title: 'Collection 1', tenant: 'tenant1' },
-          { id: 'collection3', title: 'Public Collection', tenant: '' },
+          {
+            id: 'collection1',
+            title: 'Collection 1',
+            'local:tenant': 'tenant1',
+          },
+          {
+            id: 'collection3',
+            title: 'Public Collection',
+            'local:tenant': '',
+          },
           { id: 'collection4', title: 'No Tenant Collection' },
-          { id: 'collection5', title: 'Lower public tenant', tenant: 'public' },
+          {
+            id: 'collection5',
+            title: 'Lower public tenant',
+            'local:tenant': 'public',
+          },
         ],
       }),
     });
@@ -186,9 +202,13 @@ describe('GET /api/existing-collection', () => {
 
     const data = await response.json();
     expect(data.collections).toEqual([
-      { id: 'collection3', title: 'Public Collection', tenant: '' },
+      { id: 'collection3', title: 'Public Collection', 'local:tenant': '' },
       { id: 'collection4', title: 'No Tenant Collection' },
-      { id: 'collection5', title: 'Lower public tenant', tenant: 'public' },
+      {
+        id: 'collection5',
+        title: 'Lower public tenant',
+        'local:tenant': 'public',
+      },
     ]);
   });
 
@@ -199,13 +219,21 @@ describe('GET /api/existing-collection', () => {
       ok: true,
       json: async () => ({
         collections: [
-          { id: 'collection3', title: 'Public Collection', tenant: '' },
+          {
+            id: 'collection3',
+            title: 'Public Collection',
+            'local:tenant': '',
+          },
           { id: 'collection4', title: 'No Tenant Collection' },
-          { id: 'collection6', title: 'Upper public tenant', tenant: 'Public' },
+          {
+            id: 'collection6',
+            title: 'Upper public tenant',
+            'local:tenant': 'Public',
+          },
           {
             id: 'collection7',
             title: 'Tenant 2 Collection',
-            tenant: 'tenant2',
+            'local:tenant': 'tenant2',
           },
         ],
       }),
@@ -223,9 +251,13 @@ describe('GET /api/existing-collection', () => {
 
     const data = await response.json();
     expect(data.collections).toEqual([
-      { id: 'collection3', title: 'Public Collection', tenant: '' },
+      { id: 'collection3', title: 'Public Collection', 'local:tenant': '' },
       { id: 'collection4', title: 'No Tenant Collection' },
-      { id: 'collection6', title: 'Upper public tenant', tenant: 'Public' },
+      {
+        id: 'collection6',
+        title: 'Upper public tenant',
+        'local:tenant': 'Public',
+      },
     ]);
   });
 
@@ -267,7 +299,9 @@ describe('GET /api/existing-collection', () => {
     // Should include: tenant1 collections, Public collections, and collections with no tenant
     const allowedCollections = data.collections.filter(
       (col: StacCollection) =>
-        !col.tenant || col.tenant === '' || col.tenant === 'tenant1'
+        !col['local:tenant'] ||
+        col['local:tenant'] === '' ||
+        col['local:tenant'] === 'tenant1'
     );
     expect(allowedCollections).toHaveLength(3); // collection1, collection3, collection4
   });

--- a/__tests__/api/ExistingCollectionRoute.test.ts
+++ b/__tests__/api/ExistingCollectionRoute.test.ts
@@ -51,6 +51,7 @@ type StacCollection = {
   id: string;
   title: string;
   'local:tenant'?: string;
+  tenant?: string;
 };
 
 const mockStacCollectionsResponse: { collections: StacCollection[] } = {
@@ -304,6 +305,53 @@ describe('GET /api/existing-collection', () => {
         col['local:tenant'] === 'tenant1'
     );
     expect(allowedCollections).toHaveLength(3); // collection1, collection3, collection4
+  });
+
+  it('treats the authoritative tenant key as the only tenant key for filtering', async () => {
+    authMock.mockResolvedValue(mockSession);
+    getUserTenantsMock.mockResolvedValue(['tenant1']);
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        collections: [
+          {
+            id: 'collection-authoritative-deny',
+            title: 'Authoritative tenant wins',
+            'local:tenant': 'tenant2',
+            tenant: 'tenant1',
+          },
+          {
+            id: 'collection-legacy-only',
+            title: 'Legacy tenant only',
+            tenant: 'tenant1',
+          },
+          {
+            id: 'collection-public',
+            title: 'Public collection',
+          },
+        ],
+      }),
+    });
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/existing-collection'
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.collections).toEqual([
+      {
+        id: 'collection-legacy-only',
+        title: 'Legacy tenant only',
+        tenant: 'tenant1',
+      },
+      {
+        id: 'collection-public',
+        title: 'Public collection',
+      },
+    ]);
   });
 
   it('handles network errors gracefully', async () => {

--- a/__tests__/components/CreationFormManager.test.tsx
+++ b/__tests__/components/CreationFormManager.test.tsx
@@ -330,12 +330,13 @@ describe('CreationFormManager', () => {
       const handleSubmit = async () => {
         await defaultProps.setStatus('idle');
         // Simulate the form submission through the manager
-         const cleanedData = { ...formData };
-         if (
+        const cleanedData = { ...formData };
+        if (
           Array.isArray(cleanedData['local:tenant']) &&
           cleanedData['local:tenant'].length === 0
-         ) {
+        ) {
           delete cleanedData['local:tenant'];
+        }
 
         defaultProps.setStatus('loadingGithub');
         defaultProps.setCollectionName(cleanedData.collection as string);

--- a/__tests__/components/CreationFormManager.test.tsx
+++ b/__tests__/components/CreationFormManager.test.tsx
@@ -324,19 +324,18 @@ describe('CreationFormManager', () => {
       const [formData] = useState<Record<string, unknown>>({
         collection: 'Test Dataset',
         sample_files: 'http://example.com/file.tif',
-        tenant: [],
+        'local:tenant': [],
       });
 
       const handleSubmit = async () => {
         await defaultProps.setStatus('idle');
         // Simulate the form submission through the manager
-        const cleanedData = { ...formData };
-        if (
-          Array.isArray(cleanedData.tenant) &&
-          cleanedData.tenant.length === 0
-        ) {
-          delete cleanedData.tenant;
-        }
+         const cleanedData = { ...formData };
+         if (
+          Array.isArray(cleanedData['local:tenant']) &&
+          cleanedData['local:tenant'].length === 0
+         ) {
+          delete cleanedData['local:tenant'];
 
         defaultProps.setStatus('loadingGithub');
         defaultProps.setCollectionName(cleanedData.collection as string);

--- a/__tests__/components/PendingIngestList.test.tsx
+++ b/__tests__/components/PendingIngestList.test.tsx
@@ -36,14 +36,14 @@ describe('PendingIngestList', () => {
         title: 'Ingest Request for tenant1 Dataset',
         head: { ref: 'refs/heads/tenant1-dataset' },
       },
-      tenant: 'tenant1',
+      'local:tenant': 'tenant1',
     },
     {
       pr: {
         title: 'Ingest Request for tenant2 Dataset',
         head: { ref: 'refs/heads/tenant2-dataset' },
       },
-      tenant: 'tenant2',
+      'local:tenant': 'tenant2',
     },
     {
       pr: {
@@ -237,7 +237,7 @@ describe('PendingIngestList', () => {
               title: 'Ingest Request with explicit public tenant',
               head: { ref: 'refs/heads/public-tenant-value' },
             },
-            tenant: 'public',
+            'local:tenant': 'public',
           },
         ],
       }),

--- a/__tests__/hooks/useTenants.test.ts
+++ b/__tests__/hooks/useTenants.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { useTenants } from '../../hooks/useTenants';
 import { JSONSchema7 } from 'json-schema';
+import { getTenantFieldKey } from '@/utils/tenantField';
 
 vi.mock('@/app/contexts/TenantContext', () => ({
   useUserTenants: vi.fn(),
@@ -9,15 +10,13 @@ vi.mock('@/app/contexts/TenantContext', () => ({
 
 import { useUserTenants } from '@/app/contexts/TenantContext';
 import type { Mock } from 'vitest';
+
 const mockedUseUserTenants = useUserTenants as Mock;
+const tenantFieldKey = getTenantFieldKey();
 
 const baseSchema: JSONSchema7 = {
   type: 'object',
-  properties: {
-    tenant: {
-      type: 'string',
-    },
-  },
+  properties: {},
 };
 
 describe('useTenants', () => {
@@ -44,8 +43,13 @@ describe('useTenants', () => {
     mockedUseUserTenants.mockReturnValue(mockContextValue);
 
     const { result } = renderHook(() => useTenants(baseSchema));
-    expect(result.current.schema.properties?.tenant?.type).toBe('string');
-    expect(result.current.schema.properties?.tenant?.enum).toEqual(mockTenants);
+    expect(result.current.schema.properties?.[tenantFieldKey]?.type).toBe('string');
+    expect(result.current.schema.properties?.[tenantFieldKey]?.title).toBe(
+      'Tenants'
+    );
+    expect(result.current.schema.properties?.[tenantFieldKey]?.enum).toEqual(
+      mockTenants
+    );
     expect(result.current.isLoading).toBe(false);
   });
 
@@ -58,8 +62,10 @@ describe('useTenants', () => {
     mockedUseUserTenants.mockReturnValue(mockContextValue);
 
     const { result } = renderHook(() => useTenants(baseSchema));
-    expect(result.current.schema.properties?.tenant?.type).toBe('string');
-    expect(result.current.schema.properties?.tenant?.enum).toEqual(mockTenants);
+    expect(result.current.schema.properties?.[tenantFieldKey]?.type).toBe('string');
+    expect(result.current.schema.properties?.[tenantFieldKey]?.enum).toEqual(
+      mockTenants
+    );
     expect(result.current.isLoading).toBe(true);
   });
 
@@ -73,7 +79,7 @@ describe('useTenants', () => {
     const schemaWithTenant: JSONSchema7 = {
       type: 'object',
       properties: {
-        tenant: {
+        'local:tenant': {
           type: 'string',
           enum: ['testTenant'],
         },
@@ -84,7 +90,7 @@ describe('useTenants', () => {
     };
 
     const { result } = renderHook(() => useTenants(schemaWithTenant));
-    expect(result.current.schema.properties?.tenant).toBeUndefined();
+    expect(result.current.schema.properties?.['local:tenant']).toBeUndefined();
     expect(result.current.schema.properties?.other).toBeDefined();
   });
 
@@ -96,7 +102,7 @@ describe('useTenants', () => {
     mockedUseUserTenants.mockReturnValue(mockContextValue);
 
     const baseUiSchema = {
-      'ui:grid': [{ tenant: 12 }, { other: 12 }],
+      'ui:grid': [{ [tenantFieldKey]: 12 }, { other: 12 }],
     };
 
     const { result } = renderHook(() => useTenants(baseSchema, baseUiSchema));
@@ -111,10 +117,54 @@ describe('useTenants', () => {
     mockedUseUserTenants.mockReturnValue(mockContextValue);
 
     const schemaCopy = JSON.parse(JSON.stringify(baseSchema));
-    const uiSchemaCopy = { 'ui:grid': [{ tenant: 12 }] };
+    const uiSchemaCopy = { 'ui:grid': [{ [tenantFieldKey]: 12 }] };
 
     renderHook(() => useTenants(schemaCopy, uiSchemaCopy));
     expect(schemaCopy).toEqual(baseSchema);
-    expect(uiSchemaCopy).toEqual({ 'ui:grid': [{ tenant: 12 }] });
+    expect(uiSchemaCopy).toEqual({ 'ui:grid': [{ [tenantFieldKey]: 12 }] });
+  });
+
+  it('should preserve dynamic tenant ui schema keys when tenants are available', () => {
+    mockedUseUserTenants.mockReturnValue({
+      tenants: ['tenant-X'],
+      isLoading: false,
+    });
+
+    const baseUiSchema = {
+      'ui:grid': [{ [tenantFieldKey]: 12 }, { other: 12 }],
+      [tenantFieldKey]: {
+        'ui:placeholder': 'Select a tenant',
+      },
+    };
+
+    const { result } = renderHook(() => useTenants(baseSchema, baseUiSchema));
+
+    expect(result.current.uiSchema?.['ui:grid']).toEqual([
+      { [tenantFieldKey]: 12 },
+      { other: 12 },
+    ]);
+    expect(result.current.uiSchema?.[tenantFieldKey]).toEqual({
+      'ui:placeholder': 'Select a tenant',
+    });
+  });
+
+  it('should add a dynamic tenant ui schema key when one is missing', () => {
+    mockedUseUserTenants.mockReturnValue({
+      tenants: ['tenant-X'],
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() =>
+      useTenants(baseSchema, { 'ui:grid': [{ other: 12 }] })
+    );
+
+    expect(result.current.uiSchema?.['ui:grid']).toEqual([
+      { [tenantFieldKey]: 24 },
+      { other: 12 },
+    ]);
+    expect(result.current.uiSchema?.[tenantFieldKey]).toEqual({
+      classNames: 'tenants-field',
+      'ui:help': 'Optional tenant allowed to access this item.',
+    });
   });
 });

--- a/__tests__/playwright/CreateCollectionPageTenants.test.tsx
+++ b/__tests__/playwright/CreateCollectionPageTenants.test.tsx
@@ -77,7 +77,7 @@ test.describe('Tenant Functionality - Create Collection Page', () => {
         const postData = request.postDataJSON();
 
         expect(
-          postData.data.tenant,
+          postData.data['local:tenant'],
           'tenant key value should match selection'
         ).toEqual('tenant2');
 
@@ -159,7 +159,7 @@ test.describe('Tenant Functionality - Create Collection Page', () => {
         expect(
           postData.data,
           'tenant key should not be included'
-        ).not.toHaveProperty('tenant');
+        ).not.toHaveProperty('local:tenant');
 
         await route.fulfill({
           status: 200,
@@ -199,7 +199,7 @@ test.describe('Tenant Functionality - Create Collection Page', () => {
         const postData = request.postDataJSON();
 
         expect(
-          postData.data.tenant,
+          postData.data['local:tenant'],
           'tenant key value should match JSON entry'
         ).toEqual('tenant3');
 
@@ -224,7 +224,7 @@ test.describe('Tenant Functionality - Create Collection Page', () => {
     await test.step('paste JSON with tenants', async () => {
       const configWithTenants = {
         ...requiredCollectionConfig,
-        tenant: 'tenant3',
+        'local:tenant': 'tenant3',
       };
       await page
         .getByTestId('json-editor')
@@ -270,7 +270,7 @@ test.describe('Tenant Functionality - Create Collection Page', () => {
 
       const invalidConfig = {
         ...requiredCollectionConfig,
-        tenant: 'unauthorized-tenant',
+        'local:tenant': 'unauthorized-tenant',
       };
 
       await page
@@ -282,9 +282,12 @@ test.describe('Tenant Functionality - Create Collection Page', () => {
       await page.getByRole('button', { name: /apply changes/i }).click();
 
       await expect(
-        page.getByText('"tenant must be equal to one of the allowed values"', {
-          exact: true,
-        }),
+        page.getByText(
+          `"local:tenant must be equal to one of the allowed values"`,
+          {
+            exact: true,
+          }
+        ),
         'Should show validation error'
       ).toBeVisible();
 
@@ -322,7 +325,7 @@ test.describe('Tenant Functionality - Create Collection Page', () => {
         expect(
           postData.data,
           'tenant key should not be included'
-        ).not.toHaveProperty('tenant');
+        ).not.toHaveProperty('local:tenant');
 
         await route.fulfill({
           status: 200,

--- a/__tests__/playwright/CreateDatasetPageTenants.test.tsx
+++ b/__tests__/playwright/CreateDatasetPageTenants.test.tsx
@@ -144,7 +144,7 @@ test.describe('Tenant Functionality - Create Dataset Page', () => {
         const postData = request.postDataJSON();
 
         expect(
-          postData.data.tenant,
+          postData.data['local:tenant'],
           'tenant key value should match selection'
         ).toEqual('tenant1');
 
@@ -230,7 +230,7 @@ test.describe('Tenant Functionality - Create Dataset Page', () => {
         expect(
           postData.data,
           'tenant key should not be included'
-        ).not.toHaveProperty('tenant');
+        ).not.toHaveProperty('local:tenant');
 
         await route.fulfill({
           status: 200,
@@ -270,7 +270,7 @@ test.describe('Tenant Functionality - Create Dataset Page', () => {
         const postData = request.postDataJSON();
 
         expect(
-          postData.data.tenant,
+          postData.data['local:tenant'],
           'tenant key value should match JSON entry'
         ).toEqual('tenant2');
 
@@ -295,7 +295,7 @@ test.describe('Tenant Functionality - Create Dataset Page', () => {
     await test.step('paste JSON with tenants', async () => {
       const configWithTenants = {
         ...requiredConfig,
-        tenant: 'tenant2',
+        'local:tenant': 'tenant2',
       };
       await page
         .getByTestId('json-editor')
@@ -340,7 +340,7 @@ test.describe('Tenant Functionality - Create Dataset Page', () => {
 
       const invalidConfig = {
         ...requiredConfig,
-        tenant: 'unauthorized-tenant',
+        'local:tenant': 'unauthorized-tenant',
       };
 
       await page
@@ -349,9 +349,12 @@ test.describe('Tenant Functionality - Create Dataset Page', () => {
       await page.getByRole('button', { name: /apply changes/i }).click();
 
       await expect(
-        page.getByText('"tenant must be equal to one of the allowed values"', {
-          exact: true,
-        }),
+        page.getByText(
+          `"local:tenant must be equal to one of the allowed values"`,
+          {
+            exact: true,
+          }
+        ),
         'Should show validation error'
       ).toBeVisible();
 
@@ -389,7 +392,7 @@ test.describe('Tenant Functionality - Create Dataset Page', () => {
         expect(
           postData.data,
           'tenant key should not be in POST data'
-        ).not.toHaveProperty('tenant');
+        ).not.toHaveProperty('local:tenant');
 
         await route.fulfill({
           status: 200,

--- a/__tests__/playwright/EditCollectionPageTenants.test.tsx
+++ b/__tests__/playwright/EditCollectionPageTenants.test.tsx
@@ -139,7 +139,7 @@ test.describe('Tenant Functionality - Edit Collection Page', () => {
         putRequestIntercepted = true;
         const putData = request.postDataJSON();
 
-        expect(putData.formData.tenant).toEqual('tenant1');
+        expect(putData.formData['local:tenant']).toEqual('tenant1');
 
         await route.fulfill({
           status: 200,
@@ -226,7 +226,7 @@ test.describe('Tenant Functionality - Edit Collection Page', () => {
         putRequestIntercepted = true;
         const putData = request.postDataJSON();
 
-        expect(putData.formData.tenant).toEqual('tenant3');
+        expect(putData.formData['local:tenant']).toEqual('tenant3');
 
         await route.fulfill({
           status: 200,
@@ -249,7 +249,7 @@ test.describe('Tenant Functionality - Edit Collection Page', () => {
       const updatedConfig = {
         ...modifiedCollectionConfig,
         id: 'Playwright_TEST',
-        tenant: 'tenant3',
+        'local:tenant': 'tenant3',
       };
 
       await expect(
@@ -351,7 +351,7 @@ test.describe('Tenant Functionality - Edit Collection Page', () => {
       const invalidConfig = {
         ...modifiedCollectionConfig,
         id: 'Playwright_TEST',
-        tenant: 'unauthorized-tenant',
+        'local:tenant': 'unauthorized-tenant',
       };
 
       await page
@@ -364,9 +364,12 @@ test.describe('Tenant Functionality - Edit Collection Page', () => {
 
       // Should show validation error
       await expect(
-        page.getByText('"tenant must be equal to one of the allowed values"', {
-          exact: true,
-        })
+        page.getByText(
+          `"local:tenant must be equal to one of the allowed values"`,
+          {
+            exact: true,
+          }
+        )
       ).toBeVisible();
     });
   });

--- a/__tests__/playwright/EditDatasetPage.test.tsx
+++ b/__tests__/playwright/EditDatasetPage.test.tsx
@@ -6,7 +6,7 @@ const modifiedConfig = {
   title: 'test title',
   description: 'test description — now with more details! 🙂',
   license: 'test license',
-  tenant: 'tenant2',
+  'local:tenant': 'tenant2',
   discovery_items: [
     {
       filename_regex: '.*_\\d{6}.tif$',

--- a/__tests__/playwright/EditDatasetPageTenants.test.tsx
+++ b/__tests__/playwright/EditDatasetPageTenants.test.tsx
@@ -5,7 +5,6 @@ const modifiedConfig = {
   title: 'test title',
   description: 'test description',
   license: 'test license',
-  tenant: 'tenant2',
   discovery_items: [
     {
       filename_regex: '(.*)Test_(.*).tif$',
@@ -70,7 +69,7 @@ test.describe('Edit Dataset Page', () => {
         putRequestIntercepted = true;
         const putData = request.postDataJSON();
 
-        expect(putData.formData.tenant).toEqual('tenant1');
+        expect(putData.formData['local:tenant']).toEqual('tenant1');
 
         await route.fulfill({
           status: 200,
@@ -158,7 +157,7 @@ test.describe('Edit Dataset Page', () => {
         putRequestIntercepted = true;
         const putData = request.postDataJSON();
 
-        expect(putData.formData.tenant).toEqual('tenant3');
+        expect(putData.formData['local:tenant']).toEqual('tenant3');
 
         await route.fulfill({
           status: 200,
@@ -180,7 +179,7 @@ test.describe('Edit Dataset Page', () => {
     await test.step('edit dataset via JSON Editor', async () => {
       const updatedConfig = {
         ...modifiedConfig,
-        tenant: 'tenant3',
+        'local:tenant': 'tenant3',
       };
 
       await expect(
@@ -266,7 +265,7 @@ test.describe('Edit Dataset Page', () => {
 
       const invalidConfig = {
         ...modifiedConfig,
-        tenant: 'unauthorized-tenant',
+        'local:tenant': 'unauthorized-tenant',
       };
 
       await page
@@ -276,9 +275,12 @@ test.describe('Edit Dataset Page', () => {
 
       // Should show validation error
       await expect(
-        page.getByText('"tenant must be equal to one of the allowed values"', {
-          exact: true,
-        })
+        page.getByText(
+          `"local:tenant must be equal to one of the allowed values"`,
+          {
+            exact: true,
+          }
+        )
       ).toBeVisible();
     });
   });

--- a/__tests__/utils/ListPRs.test.ts
+++ b/__tests__/utils/ListPRs.test.ts
@@ -4,6 +4,7 @@ vi.mock('@/config/env', () => ({
     OWNER: 'test-owner',
     REPO: 'test-repo',
     TARGET_BRANCH: 'main',
+    VEDA_TENANT_FILTER_FIELD: 'local:tenant',
     AWS_REGION: 'us-west-2',
     NEXT_PUBLIC_AWS_S3_BUCKET_NAME: 'mock-bucket',
   },
@@ -75,7 +76,7 @@ describe('ListPRs Utility', () => {
       ],
     });
     const fileContent = Buffer.from(
-      JSON.stringify({ tenant: 'tenant2' })
+      JSON.stringify({ 'local:tenant': 'tenant2' })
     ).toString('base64');
     mockGetContent.mockResolvedValue({
       data: { content: fileContent },

--- a/__tests__/utils/ListPRsFallback.test.ts
+++ b/__tests__/utils/ListPRsFallback.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest';
+
+const mockList = vi.fn();
+const mockListFiles = vi.fn();
+const mockGetContent = vi.fn();
+
+const mockOctokitInstance = {
+  rest: {
+    pulls: {
+      list: mockList,
+      listFiles: mockListFiles,
+    },
+    repos: {
+      getContent: mockGetContent,
+    },
+  },
+};
+
+vi.mock('@octokit/rest', () => ({
+  Octokit: vi.fn(() => mockOctokitInstance),
+}));
+
+vi.mock('@/utils/githubUtils/GetGithubToken', () => ({
+  default: vi.fn().mockResolvedValue('mocked-github-token'),
+}));
+
+describe('ListPRs fallback tenant behavior', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  beforeAll(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('falls back to eic:tenant when VEDA_TENANT_FILTER_FIELD is unset and ignores other tenant-like keys', async () => {
+    vi.doMock('@/config/env', () => ({
+      cfg: {
+        OWNER: 'test-owner',
+        REPO: 'test-repo',
+        TARGET_BRANCH: 'main',
+        AWS_REGION: 'us-west-2',
+        NEXT_PUBLIC_AWS_S3_BUCKET_NAME: 'mock-bucket',
+      },
+    }));
+
+    const { default: ListPRs } = await import('@/utils/githubUtils/ListPRs');
+
+    const pr = { number: 1, head: { sha: 'abc123' } };
+    mockList.mockResolvedValue({ data: [pr] });
+    mockListFiles.mockResolvedValue({
+      data: [{ filename: 'ingestion-data/staging/collections/test.json' }],
+    });
+
+    const fileContent = Buffer.from(
+      JSON.stringify({
+        'eic:tenant': 'tenant-eic',
+        'foo:tenant': 'tenant-foo',
+        tenant: 'tenant-legacy',
+      })
+    ).toString('base64');
+
+    mockGetContent.mockResolvedValue({
+      data: { content: fileContent },
+    });
+
+    const result = await ListPRs('collection');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].pr).toEqual(pr);
+    expect(result[0].tenant).toBe('tenant-eic');
+  });
+});

--- a/app/api/create-ingest/route.ts
+++ b/app/api/create-ingest/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { validateTenantAccess } from '@/lib/serverTenantValidation';
+import { getTenantFieldKey } from '@/utils/tenantField';
 
 import CreatePR from '@/utils/githubUtils/CreatePR';
 import UpdatePR from '@/utils/githubUtils/UpdatePR';
@@ -49,7 +50,11 @@ export async function POST(request: NextRequest) {
 
     const validatedIngestionType: AllowedIngestionType = ingestionType;
 
-    if (data.tenant) {
+    const tenantFieldKey = getTenantFieldKey();
+    const tenantValue = data[tenantFieldKey];
+    const tenant = typeof tenantValue === 'string' ? tenantValue : undefined;
+
+    if (tenant && tenant !== '' && tenant.toLowerCase() !== 'public') {
       const session = await auth();
       if (!session) {
         return NextResponse.json(
@@ -58,7 +63,7 @@ export async function POST(request: NextRequest) {
         );
       }
 
-      const tenantValidation = await validateTenantAccess(data.tenant, request);
+      const tenantValidation = await validateTenantAccess(tenant, request);
       if (!tenantValidation.isValid) {
         return NextResponse.json(
           {
@@ -124,7 +129,11 @@ export async function PUT(request: NextRequest) {
 
     const { gitRef, fileSha, filePath, formData } = body;
 
-    if (formData?.tenant) {
+    const tenantFieldKey = getTenantFieldKey();
+    const tenantValue = formData?.[tenantFieldKey];
+    const tenant = typeof tenantValue === 'string' ? tenantValue : undefined;
+
+    if (tenant && tenant !== '' && tenant.toLowerCase() !== 'public') {
       const session = await auth();
       if (!session) {
         return NextResponse.json(
@@ -133,10 +142,7 @@ export async function PUT(request: NextRequest) {
         );
       }
 
-      const tenantValidation = await validateTenantAccess(
-        formData.tenant,
-        request
-      );
+      const tenantValidation = await validateTenantAccess(tenant, request);
       if (!tenantValidation.isValid) {
         return NextResponse.json(
           {

--- a/app/api/existing-collection/[collectionId]/route.ts
+++ b/app/api/existing-collection/[collectionId]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { validateTenantAccess } from '@/lib/serverTenantValidation';
 import { VEDA_PROD_BACKEND_URL } from '@/config/env';
+import { getTenantFieldKey } from '@/utils/tenantField';
 
 interface RouteParams {
   params: Promise<{
@@ -11,6 +12,8 @@ interface RouteParams {
 
 export async function GET(request: NextRequest, { params }: RouteParams) {
   try {
+    const tenantFieldKey = getTenantFieldKey();
+
     const session = await auth();
     if (!session) {
       return NextResponse.json(
@@ -49,22 +52,25 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     }
 
     const collectionData = await stacResponse.json();
+    const collectionTenantValue = collectionData?.[tenantFieldKey];
+    const collectionTenant =
+      typeof collectionTenantValue === 'string' ? collectionTenantValue : undefined;
 
     // Validate tenant access if collection has a tenant
     if (
-      collectionData.tenant &&
-      collectionData.tenant !== '' &&
-      collectionData.tenant !== 'Public'
+      collectionTenant &&
+      collectionTenant !== '' &&
+      collectionTenant.toLowerCase() !== 'public'
     ) {
       const tenantValidation = await validateTenantAccess(
-        collectionData.tenant,
+        collectionTenant,
         session
       );
 
       if (!tenantValidation.isValid) {
         return NextResponse.json(
           {
-            error: `Access denied for collection from tenant: ${collectionData.tenant}`,
+            error: `Access denied for collection from tenant: ${collectionTenant}`,
           },
           { status: 403 }
         );
@@ -83,6 +89,8 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
 
 export async function PUT(request: NextRequest, { params }: RouteParams) {
   try {
+    const tenantFieldKey = getTenantFieldKey();
+
     const session = await auth();
     if (!session) {
       return NextResponse.json(
@@ -122,22 +130,25 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
     }
 
     const existingCollection = await existingResponse.json();
+    const existingTenantValue = existingCollection?.[tenantFieldKey];
+    const existingTenant =
+      typeof existingTenantValue === 'string' ? existingTenantValue : undefined;
 
     // Validate tenant access if collection has a tenant
     if (
-      existingCollection.tenant &&
-      existingCollection.tenant !== '' &&
-      existingCollection.tenant !== 'Public'
+      existingTenant &&
+      existingTenant !== '' &&
+      existingTenant.toLowerCase() !== 'public'
     ) {
       const tenantValidation = await validateTenantAccess(
-        existingCollection.tenant,
+        existingTenant,
         session
       );
 
       if (!tenantValidation.isValid) {
         return NextResponse.json(
           {
-            error: `Access denied for collection from tenant: ${existingCollection.tenant}`,
+            error: `Access denied for collection from tenant: ${existingTenant}`,
           },
           { status: 403 }
         );

--- a/app/api/existing-collection/route.ts
+++ b/app/api/existing-collection/route.ts
@@ -2,9 +2,9 @@ import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { getUserTenants } from '@/lib/serverTenantValidation';
 import { VEDA_PROD_BACKEND_URL } from '@/config/env';
+import { getTenantFieldKey } from '@/utils/tenantField';
 
 type StacCollection = {
-  tenant?: string;
   [key: string]: unknown;
 };
 
@@ -35,6 +35,12 @@ export async function GET(request: NextRequest) {
 
     // Get user's allowed tenants
     const userTenants = await getUserTenants(session);
+
+    const tenantFieldKey = getTenantFieldKey();
+    const getCollectionTenant = (collection: StacCollection): string | undefined => {
+      const tenant = collection[tenantFieldKey];
+      return typeof tenant === 'string' ? tenant : undefined;
+    };
 
     const { searchParams } = new URL(request.url);
     const tenantFilter = searchParams.get('tenant');
@@ -85,10 +91,11 @@ export async function GET(request: NextRequest) {
 
     if (isPublicFilter && stacData.collections) {
       stacData.collections = stacData.collections.filter((collection) => {
-        const collectionTenant = collection.tenant?.toLowerCase?.();
+        const tenant = getCollectionTenant(collection);
+        const collectionTenant = tenant?.toLowerCase();
         return (
-          !collection.tenant ||
-          collection.tenant === '' ||
+          !tenant ||
+          tenant === '' ||
           collectionTenant === 'public'
         );
       });
@@ -97,11 +104,12 @@ export async function GET(request: NextRequest) {
     // Filter collections by user's allowed tenants if no specific tenant filter
     if (!normalizedTenantFilter && stacData.collections) {
       stacData.collections = stacData.collections.filter((collection) => {
+        const tenant = getCollectionTenant(collection);
         // Allow public collections (no tenant property or empty tenant)
-        if (!collection.tenant || collection.tenant === '') {
+        if (!tenant || tenant === '' || tenant.toLowerCase() === 'public') {
           return true;
         }
-        return userTenants.includes(collection.tenant);
+        return userTenants.includes(tenant);
       });
     }
 

--- a/app/api/list-ingests/route.ts
+++ b/app/api/list-ingests/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { getUserTenants } from '@/lib/serverTenantValidation';
+import { getTenantFieldKey } from '@/utils/tenantField';
 
 import ListPRs from '@/utils/githubUtils/ListPRs';
 
@@ -34,6 +35,8 @@ export async function GET(request: NextRequest) {
 
     const allIngests = await ListPRs(ingestionType);
 
+    const tenantFieldKey = getTenantFieldKey();
+
     const filteredIngests = allIngests.filter((ingest) => {
       const fileTenant = ingest.tenant;
 
@@ -46,7 +49,23 @@ export async function GET(request: NextRequest) {
       return userTenants.includes(fileTenant);
     });
 
-    return NextResponse.json({ githubResponse: filteredIngests });
+    const tenantKeyedIngests = filteredIngests.map((ingest) => {
+      const ingestRecord = ingest as unknown as Record<string, unknown>;
+      const tenant = ingestRecord.tenant;
+
+      if (typeof tenant !== 'string') {
+        return ingestRecord;
+      }
+
+      const { tenant: _tenant, ...rest } = ingestRecord;
+      void _tenant;
+      return {
+        ...rest,
+        [tenantFieldKey]: tenant,
+      };
+    });
+
+    return NextResponse.json({ githubResponse: tenantKeyedIngests });
   } catch (error) {
     console.error('Error in /api/list-ingest:', error);
     if (error instanceof Error) {

--- a/components/ingestion/CollectionIngestionForm.tsx
+++ b/components/ingestion/CollectionIngestionForm.tsx
@@ -103,6 +103,8 @@ function CollectionIngestionForm({
     ? { ...dynamicUiSchema, ...lockedFormFields }
     : { ...uiSchema, ...lockedFormFields };
 
+  const formScopedData = formData;
+
   const prevFormDataRef = useRef(formData);
   useEffect(() => {
     const wasCleared =
@@ -179,17 +181,17 @@ function CollectionIngestionForm({
     const rjsfData: Record<string, unknown> = {};
     const additional: Record<string, unknown> = {};
 
-    if (formData) {
-      for (const key in formData) {
+    if (formScopedData) {
+      for (const key in formScopedData) {
         if (baseKeys.has(key)) {
-          rjsfData[key] = formData[key];
+          rjsfData[key] = formScopedData[key];
         } else if (key !== 'summaries' && !currentExtensionKeys.has(key)) {
-          additional[key] = formData[key];
+          additional[key] = formScopedData[key];
         }
       }
     }
     return { rjsfFormData: rjsfData, additionalProperties: additional };
-  }, [formData, extensionFields, dynamicSchema]);
+  }, [dynamicSchema, extensionFields, formScopedData]);
 
   const [summariesData, setSummariesData] = useState(
     rjsfFormData.summaries || {}
@@ -224,12 +226,15 @@ function CollectionIngestionForm({
     if (!validateExtensionFields()) {
       return;
     }
-    onSubmit({ ...formData, summaries: summariesData });
+    onSubmit({
+      ...(formData ?? {}),
+      summaries: summariesData,
+    });
   }, [validateExtensionFields, formData, summariesData, onSubmit]);
 
   const handleJsonEditorChange = useCallback(
     (updatedData: JSONEditorValue) => {
-      setFormData(updatedData);
+      setFormData((updatedData as Record<string, unknown>) ?? {});
       // When JSON is edited, also update the separated summaries state
       setSummariesData(
         (updatedData.summaries as Record<string, unknown>) || {}
@@ -394,7 +399,7 @@ function CollectionIngestionForm({
                 }
               >
                 <JSONEditor
-                  value={formData || {}}
+                  value={formScopedData || {}}
                   jsonSchema={dynamicSchema}
                   onChange={handleJsonEditorChange}
                   disableIdChange={isEditMode}
@@ -402,11 +407,11 @@ function CollectionIngestionForm({
                     isExistingCollectionEditMode
                       ? {
                           summaries: {
-                            value: formData?.summaries,
+                            value: formScopedData?.summaries,
                             label: 'Summaries',
                           },
                           links: {
-                            value: formData?.links,
+                            value: formScopedData?.links,
                             label: 'Links',
                           },
                         }

--- a/components/ingestion/CreationFormManager.tsx
+++ b/components/ingestion/CreationFormManager.tsx
@@ -6,6 +6,7 @@ import { Status } from '@/types/global';
 import DatasetIngestionForm from '@/components/ingestion/DatasetIngestionForm';
 import CollectionIngestionForm from '@/components/ingestion/CollectionIngestionForm';
 import { useCogValidation } from '@/hooks/useCogValidation';
+import { getTenantFieldKey } from '@/utils/tenantField';
 
 const { Title } = Typography;
 const { TextArea } = Input;
@@ -49,8 +50,12 @@ const CreationFormManager: React.FC<CreationFormManagerProps> = ({
 
     // Clean up the form data
     const cleanedData = { ...data };
-    if (Array.isArray(cleanedData.tenant) && cleanedData.tenant.length === 0) {
-      delete cleanedData.tenant;
+    const tenantFieldKey = getTenantFieldKey();
+    if (
+      Array.isArray(cleanedData[tenantFieldKey]) &&
+      cleanedData[tenantFieldKey].length === 0
+    ) {
+      delete cleanedData[tenantFieldKey];
     }
 
     setStagedFormData(cleanedData);

--- a/components/ingestion/DatasetIngestionForm.tsx
+++ b/components/ingestion/DatasetIngestionForm.tsx
@@ -120,6 +120,8 @@ function DatasetIngestionForm({
     ? { ...dynamicUiSchema, ...lockedFormFields }
     : { ...uiSchema, ...lockedFormFields };
 
+  const formScopedData = formData;
+
   // --- Set initial "default" data for new forms ---
   useEffect(() => {
     if (!isEditMode && (!formData || Object.keys(formData).length === 0)) {
@@ -201,7 +203,8 @@ function DatasetIngestionForm({
 
   const onFormDataChanged = useCallback(
     (formState: { formData?: object }) => {
-      setFormData((formState.formData as Record<string, unknown>) ?? {});
+      const nextData = (formState.formData as Record<string, unknown>) ?? {};
+      setFormData(nextData);
       if (setDisabled) {
         setDisabled(false);
       }
@@ -211,7 +214,7 @@ function DatasetIngestionForm({
 
   const handleJsonEditorChange = useCallback(
     (updatedData: JSONEditorValue) => {
-      setFormData(updatedData);
+      setFormData((updatedData as Record<string, unknown>) ?? {});
       setForceRenderKey((prev) => prev + 1);
       setActiveTab('form');
       setHasJSONChanges(false);
@@ -225,7 +228,7 @@ function DatasetIngestionForm({
   const handleFormSubmit = useCallback(
     (rjsfData: { formData?: object }) => {
       const finalFormData = {
-        ...rjsfData.formData,
+        ...((rjsfData.formData as Record<string, unknown>) ?? {}),
         ...additionalProperties,
       };
       onSubmit(finalFormData);
@@ -276,10 +279,10 @@ function DatasetIngestionForm({
                 templates={{
                   ObjectFieldTemplate: ObjectFieldTemplate,
                 }}
-                formData={formData}
+                formData={formScopedData}
                 onChange={onFormDataChanged}
                 onSubmit={handleFormSubmit}
-                formContext={{ formData, updateFormData: setFormData }}
+                formContext={{ formData: formScopedData, updateFormData: setFormData }}
                 widgets={widgets}
               >
                 {children ? (
@@ -322,7 +325,7 @@ function DatasetIngestionForm({
               }
             >
               <JSONEditor
-                value={formData || {}}
+                value={formScopedData || {}}
                 jsonSchema={dynamicSchema}
                 onChange={handleJsonEditorChange}
                 disableCollectionNameChange={disableCollectionNameChange}

--- a/components/ingestion/PendingIngestList.tsx
+++ b/components/ingestion/PendingIngestList.tsx
@@ -8,6 +8,7 @@ import ErrorModal from '@/components/ui/ErrorModal';
 
 import { IngestPullRequest } from '@/types/ingest';
 import { useUserTenants } from '@/app/contexts/TenantContext';
+import { getTenantFieldKey } from '@/utils/tenantField';
 import { IngestColumn } from './_components/IngestColumn';
 import { SkeletonLoading } from './_components/SkeletonLoading';
 
@@ -17,6 +18,13 @@ interface PendingIngestListProps {
   ingestionType: 'dataset' | 'collection';
   onIngestSelect: (ref: string, title: string) => void;
 }
+
+const getIngestTenant = (ingest: IngestPullRequest): string | undefined => {
+  const tenantFieldKey = getTenantFieldKey();
+  const ingestRecord = ingest as unknown as Record<string, unknown>;
+  const tenant = ingestRecord[tenantFieldKey];
+  return typeof tenant === 'string' ? tenant : undefined;
+};
 
 const PendingIngestList: React.FC<PendingIngestListProps> = ({
   ingestionType,
@@ -88,9 +96,9 @@ const PendingIngestList: React.FC<PendingIngestListProps> = ({
 
   const publicIngests = allIngests.filter(
     (ingest) =>
-      !ingest.tenant ||
-      ingest.tenant === '' ||
-      ingest.tenant.toLowerCase() === 'public'
+      !getIngestTenant(ingest) ||
+      getIngestTenant(ingest) === '' ||
+      getIngestTenant(ingest)?.toLowerCase() === 'public'
   );
 
   return (
@@ -103,7 +111,7 @@ const PendingIngestList: React.FC<PendingIngestListProps> = ({
         {visibleTenants.length > 0 &&
           visibleTenants.map((tenant: string) => {
             const tenantIngests: IngestPullRequest[] = allIngests.filter(
-              (ingest: IngestPullRequest) => ingest.tenant === tenant
+              (ingest: IngestPullRequest) => getIngestTenant(ingest) === tenant
             );
 
             return (

--- a/config/env.ts
+++ b/config/env.ts
@@ -12,6 +12,7 @@ interface EnvConfig {
   ADDITIONAL_LOGO: string;
   VEDA_BACKEND_URL: string;
   VEDA_PROD_BACKEND_URL: string;
+  VEDA_TENANT_FILTER_FIELD?: string;
 }
 
 const profiles: Record<AppEnv, EnvConfig> = {
@@ -24,6 +25,7 @@ const profiles: Record<AppEnv, EnvConfig> = {
     ADDITIONAL_LOGO: '',
     VEDA_BACKEND_URL: 'https://dev.openveda.cloud/api',
     VEDA_PROD_BACKEND_URL: 'https://staging.openveda.cloud/api',
+    VEDA_TENANT_FILTER_FIELD: 'local:tenant',
   },
   disasters: {
     OWNER: 'Disasters-Learning-Portal',
@@ -54,6 +56,7 @@ const profiles: Record<AppEnv, EnvConfig> = {
     ADDITIONAL_LOGO: 'eic',
     VEDA_BACKEND_URL: 'https://eic-staging.staging.earth.gov/api',
     VEDA_PROD_BACKEND_URL: 'https://openveda.cloud/api',
+    VEDA_TENANT_FILTER_FIELD: 'eic:tenant',
   },
 };
 

--- a/hooks/useTenants.ts
+++ b/hooks/useTenants.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { JSONSchema7 } from 'json-schema';
 
 import { useUserTenants } from '@/app/contexts/TenantContext';
+import { getTenantFieldKey } from '@/utils/tenantField';
 
 /**
  * A reusable hook that takes a base JSON schema and injects the list of
@@ -21,6 +22,7 @@ export const useTenants = (
   baseUiSchema?: UiSchemaLike
 ) => {
   const { tenants, isLoading } = useUserTenants();
+  const tenantFieldKey = getTenantFieldKey();
 
   const { dynamicSchema, dynamicUiSchema } = useMemo(() => {
     // Create deep copies to avoid mutating the original objects
@@ -30,22 +32,51 @@ export const useTenants = (
       : undefined;
 
     if (!tenants || tenants.length === 0) {
-      if (newSchema.properties?.tenant) {
-        delete newSchema.properties.tenant;
+      if (newSchema.properties?.[tenantFieldKey]) {
+        delete newSchema.properties[tenantFieldKey];
+      }
+
+      if (newUiSchema?.[tenantFieldKey]) {
+        delete newUiSchema[tenantFieldKey];
       }
 
       const grid = newUiSchema?.['ui:grid'];
       if (newUiSchema && grid && grid.length > 0) {
-        newUiSchema['ui:grid'] = grid.filter(
-          (item: UiGridRow) => !Object.keys(item).includes('tenant')
-        );
+        newUiSchema['ui:grid'] = grid
+          .map((item: UiGridRow) => {
+            const updatedItem = { ...item };
+            delete updatedItem[tenantFieldKey];
+            return updatedItem;
+          })
+          .filter((item: UiGridRow) => Object.keys(item).length > 0);
       }
     } else {
-      // Add tenant enum values to the schema (single string selection)
-      if (newSchema.properties?.tenant) {
-        const tenantProperty = newSchema.properties.tenant as JSONSchema7;
-        tenantProperty.type = 'string';
-        tenantProperty.enum = tenants;
+      if (!newSchema.properties) {
+        newSchema.properties = {};
+      }
+
+      // Always inject tenant dynamically using env-based prefixed key.
+      newSchema.properties[tenantFieldKey] = {
+        type: 'string',
+        title: 'Tenants',
+        enum: tenants,
+      };
+
+      if (newUiSchema && !newUiSchema[tenantFieldKey]) {
+        newUiSchema[tenantFieldKey] = {
+          classNames: 'tenants-field',
+          'ui:help': 'Optional tenant allowed to access this item.',
+        };
+      }
+
+      const grid = newUiSchema?.['ui:grid'];
+      if (newUiSchema && grid && grid.length > 0) {
+        const hasTenantField = grid.some((item: UiGridRow) =>
+          Object.prototype.hasOwnProperty.call(item, tenantFieldKey)
+        );
+        newUiSchema['ui:grid'] = hasTenantField
+          ? grid
+          : [{ [tenantFieldKey]: 24 }, ...grid];
       }
     }
 
@@ -53,7 +84,7 @@ export const useTenants = (
       dynamicSchema: newSchema,
       dynamicUiSchema: newUiSchema,
     };
-  }, [baseSchema, baseUiSchema, tenants]);
+  }, [baseSchema, baseUiSchema, tenantFieldKey, tenants]);
 
   return {
     schema: dynamicSchema,

--- a/utils/githubUtils/ListPRs.ts
+++ b/utils/githubUtils/ListPRs.ts
@@ -1,6 +1,7 @@
 import { Octokit } from '@octokit/rest';
 import GetGithubToken from '@/utils/githubUtils/GetGithubToken';
 import { IngestPullRequest } from '@/types/ingest';
+import { getTenantFieldKey } from '@/utils/tenantField';
 
 import { cfg } from '@/config/env';
 const base = cfg.TARGET_BRANCH || 'main';
@@ -14,6 +15,14 @@ const TARGET_PATHS = {
 
 type IngestionType = 'collection' | 'dataset';
 
+const extractTenantFromContent = (
+  parsedContent: Record<string, unknown>,
+  tenantFieldKey: string
+): string | undefined => {
+  const tenant = parsedContent[tenantFieldKey];
+  return typeof tenant === 'string' ? tenant : undefined;
+};
+
 const ListPRs = async (
   ingestionType: IngestionType
 ): Promise<IngestPullRequest[]> => {
@@ -24,6 +33,7 @@ const ListPRs = async (
   }
 
   try {
+    const tenantFieldKey = getTenantFieldKey();
     const token = await GetGithubToken();
     const octokit = new Octokit({ auth: token });
     const targetPath = TARGET_PATHS[ingestionType];
@@ -65,8 +75,16 @@ const ListPRs = async (
             'base64'
           ).toString('utf-8');
           try {
-            const parsedContent = JSON.parse(fileContent);
-            return { pr, tenant: parsedContent.tenant };
+            const parsedContent = JSON.parse(fileContent) as Record<
+              string,
+              unknown
+            >;
+            const tenant = extractTenantFromContent(
+              parsedContent,
+              tenantFieldKey
+            );
+
+            return { pr, tenant };
           } catch {
             console.error(`Failed to parse JSON for PR #${pr.number}`);
             return { pr, tenant: undefined };

--- a/utils/tenantField.ts
+++ b/utils/tenantField.ts
@@ -1,0 +1,10 @@
+import { cfg } from '@/config/env';
+
+const DEFAULT_TENANT_FIELD_KEY = 'eic:tenant';
+
+export const getTenantFieldKey = () => {
+  const configuredKey = cfg.VEDA_TENANT_FILTER_FIELD?.trim();
+  return configuredKey && configuredKey.length > 0
+    ? configuredKey
+    : DEFAULT_TENANT_FIELD_KEY;
+};


### PR DESCRIPTION
closes #230 

This PR updates tenant handling to use the environment-specific `VEDA_TENANT_FILTER_FIELD` as the only authoritative tenant key, with fallback to `eic:tenant` when the variable is not set. Tenant-based filtering, permissions, create/edit flows, existing collection access, and pending ingest visibility now all rely exclusively on that configured key. Other tenant-like properties, including plain `tenant` and unrelated prefixed keys like `foo:tenant`, are treated as extra metadata and do not affect tenant behavior.

The change applies across both dataset and collection flows, including schema/UI injection, ingest payload handling, API route authorization/filtering, pending ingest grouping, and related mocks/tests. For local development and test coverage, the branch also aligns local config and test fixtures around `local:tenant` so behavior is explicit and consistent.