### PR TITLE
Feature/remove renders dashboard required fields

### DIFF
--- a/FormSchemas/datasets/datasetSchema.json
+++ b/FormSchemas/datasets/datasetSchema.json
@@ -10,8 +10,7 @@
     "temporal_extent",
     "sample_files",
     "data_type",
-    "providers",
-    "renders"
+    "providers"
   ],
   "properties": {
     "collection": {
@@ -235,7 +234,6 @@
     "renders": {
       "title": "Renders",
       "type": "object",
-      "required": ["dashboard"],
       "properties": {
         "dashboard": {
           "type": "string",

--- a/__tests__/components/DatasetIngestionForm.test.tsx
+++ b/__tests__/components/DatasetIngestionForm.test.tsx
@@ -241,6 +241,33 @@ describe('DatasetIngestionForm', () => {
     });
   });
 
+  it('strips renders when submitted as an empty array', async () => {
+    vi.mocked(useTenants).mockReturnValueOnce({
+      schema: {
+        ...mockedSchemaForTests,
+        renders: [],
+      },
+      isLoading: false,
+    } as ReturnType<typeof useTenants>);
+
+    const mockSetFormData = vi.fn();
+    render(
+      <DatasetIngestionForm
+        {...defaultProps}
+        formData={{ collection: 'initial' }}
+        setFormData={mockSetFormData}
+      />
+    );
+
+    const submitButton = screen.getByRole('button', { name: 'Submit Form' });
+    await userEvent.click(submitButton);
+
+    await waitFor(() => {
+      const submittedPayload = mockOnSubmit.mock.calls[0][0];
+      expect(submittedPayload.renders).toBeUndefined();
+    });
+  });
+
   it('switches to the JSON editor tab and handles changes', async () => {
     const TestWrapper = () => {
       const [formData, setFormData] = useState<Record<string, unknown>>({

--- a/__tests__/playwright/CreateDatasetPage.test.tsx
+++ b/__tests__/playwright/CreateDatasetPage.test.tsx
@@ -347,7 +347,6 @@ test.describe('Create Dataset Page', () => {
         'sample_files',
         'data_type',
         'providers',
-        'renders',
       ];
 
       const errorCard = page.getByTestId('extra-properties-card');

--- a/components/ingestion/DatasetIngestionForm.tsx
+++ b/components/ingestion/DatasetIngestionForm.tsx
@@ -79,42 +79,25 @@ interface FormData {
 function stripEmptyRenders(
   submittedData: Record<string, unknown>
 ): Record<string, unknown> {
-  const nextData = { ...submittedData };
-  const renders = nextData.renders;
+  const { renders, ...rest } = submittedData;
+  if (renders == null || (Array.isArray(renders) && renders.length === 0)) {
+    return rest;                                                                                                                     
+  }               
 
-  if (renders == null) {
-    delete nextData.renders;
-    return nextData;
+  if (typeof renders !== 'object' || Array.isArray(renders)) {                                                                       
+    return submittedData;
+  }                                                                                                                                  
+     
+  const isEmpty = (value: unknown): boolean => {                                                                                        
+    if (value == null) return true;                                                                                                  
+    if (typeof value === 'string') return value.trim() === '';                                                                     
+    if (Array.isArray(value)) return value.length === 0;                                                                             
+    if (typeof value === 'object') return Object.keys(value as object).length === 0;
+    return false;                                                                                                                    
   }
-
-  if (Array.isArray(renders)) {
-    if (renders.length === 0) {
-      delete nextData.renders;
-    }
-    return nextData;
-  }
-
-  if (typeof renders !== 'object') {
-    return nextData;
-  }
-
+  
   const dashboard = (renders as Record<string, unknown>).dashboard;
-  const hasDashboardEntry =
-    !(dashboard == null) &&
-    !(typeof dashboard === 'string' && dashboard.trim() === '') &&
-    !(Array.isArray(dashboard) && dashboard.length === 0) &&
-    !(
-      typeof dashboard === 'object' &&
-      dashboard !== null &&
-      !Array.isArray(dashboard) &&
-      Object.keys(dashboard as Record<string, unknown>).length === 0
-    );
-
-  if (!hasDashboardEntry) {
-    delete nextData.renders;
-  }
-
-  return nextData;
+  return isEmpty(dashboard) ? rest : submittedData;
 }
 
 const lockedFormFields = {

--- a/components/ingestion/DatasetIngestionForm.tsx
+++ b/components/ingestion/DatasetIngestionForm.tsx
@@ -76,6 +76,47 @@ interface FormData {
   temporal_extent?: TemporalExtent;
 }
 
+function stripEmptyRenders(
+  submittedData: Record<string, unknown>
+): Record<string, unknown> {
+  const nextData = { ...submittedData };
+  const renders = nextData.renders;
+
+  if (renders == null) {
+    delete nextData.renders;
+    return nextData;
+  }
+
+  if (Array.isArray(renders)) {
+    if (renders.length === 0) {
+      delete nextData.renders;
+    }
+    return nextData;
+  }
+
+  if (typeof renders !== 'object') {
+    return nextData;
+  }
+
+  const dashboard = (renders as Record<string, unknown>).dashboard;
+  const hasDashboardEntry =
+    !(dashboard == null) &&
+    !(typeof dashboard === 'string' && dashboard.trim() === '') &&
+    !(Array.isArray(dashboard) && dashboard.length === 0) &&
+    !(
+      typeof dashboard === 'object' &&
+      dashboard !== null &&
+      !Array.isArray(dashboard) &&
+      Object.keys(dashboard as Record<string, unknown>).length === 0
+    );
+
+  if (!hasDashboardEntry) {
+    delete nextData.renders;
+  }
+
+  return nextData;
+}
+
 const lockedFormFields = {
   collection: {
     'ui:readonly': true,
@@ -220,10 +261,12 @@ function DatasetIngestionForm({
 
   const handleFormSubmit = useCallback(
     (rjsfData: { formData?: object }) => {
-      const finalFormData = {
+      const mergedFormData = {
         ...((rjsfData.formData as Record<string, unknown>) ?? {}),
         ...additionalProperties,
       };
+
+      const finalFormData = stripEmptyRenders(mergedFormData);
       onSubmit(finalFormData);
     },
     [additionalProperties, onSubmit]


### PR DESCRIPTION
closes #235 

This removes the renders and renders.dashboard properties from eing required for datasets.   I also saw that if the dashboard text area was left empty during submission, then the RJSF form would send an empty object:
```json
  "renders": {}
```

This felt wrong, so I added a function to completely strip renders if there is no entry in renders.dashboard.