### PR TITLE
feat: Support disasters-specific dataset schema/profile in disasters env

### DIFF
--- a/FormSchemas/disasters/datasetSchema.json
+++ b/FormSchemas/disasters/datasetSchema.json
@@ -1,0 +1,374 @@
+{
+  "type": "object",
+  "required": [
+    "collection",
+    "title",
+    "description",
+    "license",
+    "discovery_items",
+    "spatial_extent",
+    "temporal_extent",
+    "data_type",
+    "providers"
+  ],
+  "properties": {
+    "collection": {
+      "type": "string",
+      "title": "Collection"
+    },
+    "title": {
+      "type": "string",
+      "title": "Title"
+    },
+    "description": {
+      "type": "string",
+      "title": "Description"
+    },
+    "license": {
+      "type": "string",
+      "title": "License",
+      "default": "CC0-1.0"
+    },
+    "stac_version": {
+      "type": "string",
+      "title": "STAC Version",
+      "default": "1.0.0"
+    },
+    "dashboard:is_periodic": {
+      "type": "boolean",
+      "title": "Is Periodic?"
+    },
+    "dashboard:time_density": {
+      "type": "string",
+      "enum": ["day", "month", "year"],
+      "title": "Time Density"
+    },
+    "dashboard:time_interval": {
+      "type": "string",
+      "format": "duration",
+      "title": "Time Interval"
+    },
+    "links": {
+      "title": "Links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "href": {
+            "type": "string",
+            "title": "href"
+          },
+          "rel": {
+            "type": "string",
+            "title": "rel"
+          },
+          "type": {
+            "type": "string",
+            "title": "type"
+          },
+          "title": {
+            "type": "string",
+            "title": "title"
+          },
+          "label:assets": {
+            "type": "string",
+            "title": "label:assets"
+          }
+        }
+      }
+    },
+    "spatial_extent": {
+      "title": "Spatial Extent",
+      "type": "object",
+      "properties": {
+        "xmin": {
+          "type": "number",
+          "title": "xmin"
+        },
+        "ymin": {
+          "type": "number",
+          "title": "ymin"
+        },
+        "xmax": {
+          "type": "number",
+          "title": "xmax"
+        },
+        "ymax": {
+          "type": "number",
+          "title": "ymax"
+        }
+      },
+      "default": {
+        "xmin": -180,
+        "ymin": -90,
+        "xmax": 180,
+        "ymax": 90
+      }
+    },
+    "temporal_extent": {
+      "title": "Temporal Extent",
+      "type": "object",
+      "properties": {
+        "startdate": {
+          "type": ["string", "null"],
+          "title": "Start Date"
+        },
+        "enddate": {
+          "type": ["string", "null"],
+          "title": "End Date"
+        }
+      }
+    },
+    "discovery_items": {
+      "type": "array",
+      "title": "Discovery Items",
+      "items": {
+        "type": "object",
+        "properties": {
+          "discovery": {
+            "type": "string",
+            "enum": ["s3"],
+            "title": "Discovery"
+          },
+          "prefix": {
+            "type": "string",
+            "title": "Prefix"
+          },
+          "bucket": {
+            "type": "string",
+            "title": "Bucket"
+          },
+          "filename_regex": {
+            "type": "string",
+            "title": "Filename Regex",
+            "default": "[\\s\\S]*"
+          },
+          "datetime_range": {
+            "type": "string",
+            "enum": ["day", "month", "year"],
+            "title": "Datetime Range"
+          },
+          "start_datetime": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Start Datetime"
+          },
+          "end_datetime": {
+            "type": "string",
+            "format": "date-time",
+            "title": "End Datetime"
+          },
+          "single_datetime": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Single Datetime"
+          },
+          "id_regex": {
+            "type": "string",
+            "title": "Id Regex"
+          },
+          "id_template": {
+            "type": "string",
+            "title": "Id Template"
+          },
+          "disasters:extract_event_name": {
+            "type": "boolean",
+            "title": "disasters:extract_event_name",
+            "default": true
+          },
+          "disasters:monty": {
+            "type": "boolean",
+            "title": "disasters:monty",
+            "default": true
+          },
+          "disasters:add_product": {
+            "type": "boolean",
+            "title": "disasters:add_product",
+            "default": true
+          },
+          "disasters:add_providers": {
+            "type": "boolean",
+            "title": "disasters:add_providers",
+            "default": true
+          },
+          "cogify": {
+            "type": "boolean",
+            "title": "cogify",
+            "default": false
+          },
+          "dry_run": {
+            "type": "boolean",
+            "title": "dry_run",
+            "default": false
+          },
+          "assets": {
+            "type": "object",
+            "title": "Assets",
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "title": {
+                  "type": "string",
+                  "title": "Title"
+                },
+                "description": {
+                  "type": "string",
+                  "title": "Description"
+                },
+                "regex": {
+                  "type": "string",
+                  "title": "Regex"
+                }
+              }
+            }
+          },
+          "use_multithreading": {
+            "type": "boolean",
+            "title": "Use Multithreading",
+            "default": false
+          }
+        },
+        "required": ["prefix", "bucket"]
+      },
+      "minItems": 1
+    },
+    "sample_files": {
+      "title": "Sample Files",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "data_type": {
+      "title": "Data Type",
+      "const": "cog"
+    },
+    "stac_extensions": {
+      "title": "STAC Extensions",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": [
+        "https://stac-extensions.github.io/render/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+      ]
+    },
+    "item_assets": {
+      "type": "object",
+      "title": "Item Assets",
+      "properties": {
+        "ColorIR": {
+          "type": "object",
+          "title": "ColorIR",
+          "properties": {
+            "type": {
+              "type": "string",
+              "title": "Type"
+            },
+            "roles": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "title": "Roles"
+            },
+            "title": {
+              "type": "string",
+              "title": "Title"
+            },
+            "description": {
+              "type": "string",
+              "title": "Description"
+            }
+          }
+        }
+      },
+      "default": {
+        "ColorIR": {
+          "description": "False color infrared composite combining near-infrared, red, and green bands for vegetation and land cover analysis.",
+          "roles": ["data", "layer"],
+          "title": "Color Infrared",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized"
+        }
+      },
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "title": "Type"
+          },
+          "roles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "title": "Roles"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          }
+        }
+      }
+    },
+    "renders": {
+      "title": "Renders",
+      "type": "object",
+      "properties": {
+        "dashboard": {
+          "type": ["string", "object"],
+          "title": "Dashboard"
+        },
+        "ColorIR": {
+          "type": ["string", "object"],
+          "title": "ColorIR"
+        }
+      }
+    },
+    "providers": {
+      "title": "Providers",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "title": "Organization name",
+            "type": "string",
+            "minLength": 1
+          },
+          "description": {
+            "title": "Organization description",
+            "type": "string"
+          },
+          "roles": {
+            "title": "Organization roles",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": ["producer", "licensor", "processor", "host"]
+            }
+          },
+          "url": {
+            "title": "Organization homepage",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      },
+      "default": [
+        {
+          "name": "NASA VEDA",
+          "roles": ["host"],
+          "url": "https://www.earthdata.nasa.gov/dashboard/"
+        }
+      ]
+    }
+  }
+}

--- a/FormSchemas/disasters/uischema.json
+++ b/FormSchemas/disasters/uischema.json
@@ -1,0 +1,234 @@
+{
+  "ui:grid": [
+    {
+      "collection": 8,
+      "title": 16
+    },
+    {
+      "data_type": 4,
+      "stac_version": 4,
+      "license": 4,
+      "dashboard:is_periodic": 2,
+      "dashboard:time_density": 4,
+      "dashboard:time_interval": 6
+    },
+    {
+      "description": 12,
+      "spatial_extent": 6,
+      "temporal_extent": 6
+    },
+    {
+      "discovery_items": 24
+    },
+    {
+      "sample_files": 24
+    },
+    {
+      "renders": 12,
+      "stac_extensions": 12
+    },
+    {
+      "links": 24
+    },
+    {
+      "item_assets": 24
+    },
+    {
+      "providers": 24
+    }
+  ],
+  "spatial_extent": {
+    "ui:grid": [
+      {
+        "xmin": 12,
+        "ymin": 12
+      },
+      {
+        "xmax": 12,
+        "ymax": 12
+      }
+    ]
+  },
+  "discovery_items": {
+    "items": {
+      "datetime_range": {
+        "ui:help": "omit for sub-daily data"
+      },
+      "filename_regex": {
+        "ui:widget": "regexString"
+      },
+      "id_regex": {
+        "ui:widget": "regexString"
+      },
+      "ui:grid": [
+        {
+          "discovery": 8,
+          "prefix": 8,
+          "bucket": 8
+        },
+        {
+          "filename_regex": 24
+        },
+        {
+          "stac_extensions": 12,
+          "links": 12
+        },
+        {
+          "datetime_range": 6,
+          "start_datetime": 6,
+          "end_datetime": 6,
+          "single_datetime": 6
+        },
+        {
+          "id_regex": 8,
+          "id_template": 8,
+          "use_multithreading": 8
+        },
+        {
+          "disasters:extract_event_name": 6,
+          "disasters:monty": 6,
+          "disasters:add_product": 6,
+          "disasters:add_providers": 6
+        },
+        {
+          "cogify": 12,
+          "dry_run": 12
+        },
+        {
+          "assets": 24
+        }
+      ],
+      "assets": {
+        "ui:additionalProperties": {
+          "ui:grid": [
+            {
+              "title": 12,
+              "regex": 12
+            },
+            {
+              "description": 24
+            }
+          ],
+          "description": {
+            "ui:widget": "textarea",
+            "ui:options": {
+              "rows": 4
+            }
+          }
+        }
+      }
+    }
+  },
+  "links": {
+    "items": {
+      "ui:grid": [
+        {
+          "href": 12,
+          "rel": 12
+        },
+        {
+          "type": 12,
+          "title": 12
+        },
+        {
+          "label:assets": 12
+        }
+      ]
+    }
+  },
+  "item_assets": {
+    "ColorIR": {
+      "ui:grid": [
+        {
+          "title": 12,
+          "type": 12
+        },
+        {
+          "description": 12,
+          "roles": 12
+        }
+      ],
+      "description": {
+        "ui:widget": "textarea",
+        "ui:options": {
+          "rows": 4
+        }
+      }
+    },
+    "ui:additionalProperties": {
+      "ui:grid": [
+        {
+          "title": 12,
+          "type": 12
+        },
+        {
+          "description": 12,
+          "roles": 12
+        }
+      ],
+      "description": {
+        "ui:widget": "textarea",
+        "ui:options": {
+          "rows": 4
+        }
+      }
+    }
+  },
+  "providers": {
+    "items": {
+      "ui:grid": [
+        {
+          "name": 12,
+          "description": 12
+        },
+        {
+          "roles": 12,
+          "url": 12
+        }
+      ]
+    }
+  },
+  "description": {
+    "ui:widget": "textarea",
+    "ui:options": {
+      "rows": 8,
+      "description": "This describes the dataset."
+    }
+  },
+  "renders": {
+    "dashboard": {
+      "ui:widget": "renders.dashboard",
+      "ui:options": {
+        "rows": 12
+      }
+    },
+    "ColorIR": {
+      "ui:widget": "renders.dashboard",
+      "ui:options": {
+        "rows": 12
+      }
+    },
+    "ui:classNames": "renders"
+  },
+  "temporal_extent": {
+    "startdate": {
+      "ui:widget": "text"
+    },
+    "enddate": {
+      "ui:widget": "text"
+    }
+  },
+  "ui:submitButtonOptions": {
+    "props": {
+      "color": "primary",
+      "variant": "solid",
+      "size": "large",
+      "block": "true"
+    }
+  },
+  "sample_files": {
+    "items": {
+      "ui:widget": "testableUrl"
+    }
+  }
+}

--- a/__tests__/components/DatasetIngestionForm.test.tsx
+++ b/__tests__/components/DatasetIngestionForm.test.tsx
@@ -5,6 +5,23 @@ import DatasetIngestionForm from '@/components/ingestion/DatasetIngestionForm'; 
 import React, { useState } from 'react';
 import { useTenants } from '@/hooks/useTenants';
 
+const mockedEnv = vi.hoisted(() => ({
+  DATASET_FORM_SCHEMA_PROFILE: 'default' as 'default' | 'disasters',
+}));
+
+vi.mock('@/config/env', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/config/env')>();
+  return {
+    ...actual,
+    get cfg() {
+      return {
+        ...actual.cfg,
+        DATASET_FORM_SCHEMA_PROFILE: mockedEnv.DATASET_FORM_SCHEMA_PROFILE,
+      };
+    },
+  };
+});
+
 type JsonEditorProps = {
   onChange: (value: Record<string, unknown>) => void;
 };
@@ -99,6 +116,19 @@ vi.mock('@/FormSchemas/datasets/datasetSchema.json', () => ({
 vi.mock('@/FormSchemas/datasets/uischema.json', () => ({
   default: { collection: { 'ui:widget': 'text' } },
 }));
+vi.mock('@/FormSchemas/disasters/datasetSchema.json', () => ({
+  default: {
+    type: 'object',
+    properties: {
+      disaster_only: { type: 'boolean' },
+    },
+  },
+}));
+vi.mock('@/FormSchemas/disasters/uischema.json', () => ({
+  default: {
+    disaster_only: { 'ui:widget': 'checkbox' },
+  },
+}));
 
 describe('DatasetIngestionForm', () => {
   const mockOnSubmit = vi.fn();
@@ -122,6 +152,7 @@ describe('DatasetIngestionForm', () => {
   };
 
   beforeEach(() => {
+    mockedEnv.DATASET_FORM_SCHEMA_PROFILE = 'default';
     defaultProps = {
       onSubmit: mockOnSubmit,
       setDisabled: mockSetDisabled,
@@ -323,6 +354,50 @@ describe('DatasetIngestionForm', () => {
     expect(uiSchema.collection['ui:readonly']).toBe(true);
   });
 
+  it('does not inject default item_assets for default profile on new forms', async () => {
+    mockedEnv.DATASET_FORM_SCHEMA_PROFILE = 'default';
+    const mockSetFormData = vi.fn();
+
+    render(
+      <DatasetIngestionForm
+        {...defaultProps}
+        formData={{}}
+        setFormData={mockSetFormData}
+      />
+    );
+
+    await waitFor(() => {
+      expect(mockSetFormData).toHaveBeenCalled();
+    });
+
+    const updaterFn = mockSetFormData.mock.calls[0][0];
+    const newState = updaterFn({});
+
+    expect(newState.item_assets).toBeUndefined();
+  });
+
+  it('does not inject default item_assets for disasters profile on new forms', async () => {
+    mockedEnv.DATASET_FORM_SCHEMA_PROFILE = 'disasters';
+    const mockSetFormData = vi.fn();
+
+    render(
+      <DatasetIngestionForm
+        {...defaultProps}
+        formData={{}}
+        setFormData={mockSetFormData}
+      />
+    );
+
+    await waitFor(() => {
+      expect(mockSetFormData).toHaveBeenCalled();
+    });
+
+    const updaterFn = mockSetFormData.mock.calls[0][0];
+    const newState = updaterFn({});
+
+    expect(newState.item_assets).toBeUndefined();
+  });
+
   it('correctly handles nested dashboard objects in form rendering', () => {
     const mockSetFormData = vi.fn();
     const formDataWithDashboard = {
@@ -353,5 +428,69 @@ describe('DatasetIngestionForm', () => {
 
     // Verify it's not showing '[object Object]'
     expect(formDataDiv.textContent).not.toContain('[object Object]');
+  });
+
+  it('selects schema source from env profile before tenant injection', () => {
+    mockedEnv.DATASET_FORM_SCHEMA_PROFILE = 'disasters';
+
+    vi.mocked(useTenants).mockReturnValueOnce({
+      schema: {
+        type: 'object',
+        properties: {
+          collection: { type: 'string' },
+          discovery_items: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                bucket: { type: 'string' },
+              },
+            },
+          },
+        },
+      },
+      uiSchema: {
+        discovery_items: {
+          items: {
+            bucket: {
+              'ui:widget': 'text',
+            },
+            'ui:grid': [{ bucket: 24 }],
+          },
+        },
+      },
+      isLoading: false,
+    } as ReturnType<typeof useTenants>);
+
+    const mockSetFormData = vi.fn();
+    render(
+      <DatasetIngestionForm
+        {...defaultProps}
+        formData={{ collection: 'initial' }}
+        setFormData={mockSetFormData}
+      />
+    );
+
+    const renderedSchema = JSON.parse(
+      screen.getByTestId('rjsf-schema').textContent || '{}'
+    );
+
+    expect(useTenants).toHaveBeenCalledWith(
+      {
+        type: 'object',
+        properties: {
+          disaster_only: { type: 'boolean' },
+        },
+      },
+      {
+        disaster_only: { 'ui:widget': 'checkbox' },
+      }
+    );
+
+    expect(
+      renderedSchema.properties.discovery_items.items.properties.bucket
+    ).toEqual({
+      type: 'string',
+    });
   });
 });

--- a/__tests__/pages/CreateIngestPageClient.test.tsx
+++ b/__tests__/pages/CreateIngestPageClient.test.tsx
@@ -5,9 +5,18 @@ import CreateIngestClient from '@/app/(pages)/create-dataset/_components/CreateI
 
 import { TenantContext } from '@/app/contexts/TenantContext';
 
-vi.mock('@/components/layout/AppLayout', () => ({
+vi.mock('@/components/layout/Layout', () => ({
   default: ({ children }: { children: ReactNode }) => (
     <div data-testid="app-layout">{children}</div>
+  ),
+}));
+
+vi.mock('@/components/ingestion/CreationFormManager', () => ({
+  default: () => (
+    <form>
+      <label htmlFor="collection">Collection Name</label>
+      <input id="collection" aria-label="Collection Name" />
+    </form>
   ),
 }));
 

--- a/__tests__/utils/CleanAndPrettifyJson.test.ts
+++ b/__tests__/utils/CleanAndPrettifyJson.test.ts
@@ -14,6 +14,30 @@ describe('CleanAndPrettifyJSON', () => {
     );
   });
 
+  test('parses valid JSON strings for dynamic renders keys', () => {
+    const input = {
+      name: 'Dynamic Render Key',
+      renders: {
+        dashboard: '{"assets":["ColorIR"]}',
+        ColorIR: '{"assets":["ColorIR"],"bidx":[1,2,3],"nodata":0}',
+      },
+    };
+    const output = CleanAndPrettifyJSON(input);
+    expect(output).toBe(
+      JSON.stringify(
+        {
+          name: 'Dynamic Render Key',
+          renders: {
+            dashboard: { assets: ['ColorIR'] },
+            ColorIR: { assets: ['ColorIR'], bidx: [1, 2, 3], nodata: 0 },
+          },
+        },
+        null,
+        2
+      )
+    );
+  });
+
   test('leaves renders dashboard as null if it is null', () => {
     const input = { name: 'Null Case', renders: { dashboard: null } };
     const output = CleanAndPrettifyJSON(input);
@@ -71,6 +95,31 @@ describe('CleanAndPrettifyJSON', () => {
     );
     expect(consoleWarnMock).toHaveBeenCalledWith(
       "Invalid JSON in 'renders dashboard' field. Keeping as string."
+    );
+    consoleWarnMock.mockRestore();
+  });
+
+  test('keeps dynamic renders key as string if JSON parsing fails', () => {
+    const consoleWarnMock = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => {});
+    const input = {
+      name: 'Invalid Dynamic Render JSON',
+      renders: { ColorIR: '{invalid: json}' },
+    };
+    const output = CleanAndPrettifyJSON(input);
+    expect(output).toBe(
+      JSON.stringify(
+        {
+          name: 'Invalid Dynamic Render JSON',
+          renders: { ColorIR: '{invalid: json}' },
+        },
+        null,
+        2
+      )
+    );
+    expect(consoleWarnMock).toHaveBeenCalledWith(
+      "Invalid JSON in 'renders ColorIR' field. Keeping as string."
     );
     consoleWarnMock.mockRestore();
   });

--- a/__tests__/utils/FormValidation.test.ts
+++ b/__tests__/utils/FormValidation.test.ts
@@ -4,7 +4,10 @@ import type { FormValidation } from '@rjsf/utils';
 
 type ValidationErrorsMock = {
   addError: ReturnType<typeof vi.fn>;
-  renders: { dashboard: { addError: ReturnType<typeof vi.fn> } };
+  renders: {
+    dashboard: { addError: ReturnType<typeof vi.fn> };
+    ColorIR: { addError: ReturnType<typeof vi.fn> };
+  };
   temporal_extent: {
     startdate: { addError: ReturnType<typeof vi.fn> };
     enddate: { addError: ReturnType<typeof vi.fn> };
@@ -18,7 +21,10 @@ describe('customValidate', () => {
   beforeEach(() => {
     mockErrors = {
       addError: vi.fn(),
-      renders: { dashboard: { addError: vi.fn() } },
+      renders: {
+        dashboard: { addError: vi.fn() },
+        ColorIR: { addError: vi.fn() },
+      },
       temporal_extent: {
         startdate: { addError: vi.fn() },
         enddate: { addError: vi.fn() },
@@ -79,6 +85,38 @@ describe('customValidate', () => {
     );
 
     expect(mockErrors.renders.dashboard.addError).not.toHaveBeenCalled();
+  });
+
+  it('should add an error if dynamic renders key is not valid JSON', () => {
+    const formData = { renders: { ColorIR: '{ invalid json' } };
+
+    customValidate(
+      formData,
+      mockErrors as unknown as FormValidation<Record<string, unknown>>
+    );
+
+    expect(mockErrors.renders.ColorIR.addError).toHaveBeenCalledWith(
+      'Invalid JSON format. Please enter a valid JSON object.'
+    );
+  });
+
+  it('should not add an error if dynamic renders key is a valid JSON object', () => {
+    const formData = {
+      renders: {
+        ColorIR: JSON.stringify({
+          assets: ['ColorIR'],
+          bidx: [1, 2, 3],
+          nodata: 0,
+        }),
+      },
+    };
+
+    customValidate(
+      formData,
+      mockErrors as unknown as FormValidation<Record<string, unknown>>
+    );
+
+    expect(mockErrors.renders.ColorIR.addError).not.toHaveBeenCalled();
   });
 
   it("should add an error if 'startdate' is not a string, null, or empty", () => {

--- a/components/ingestion/DatasetIngestionForm.tsx
+++ b/components/ingestion/DatasetIngestionForm.tsx
@@ -22,12 +22,15 @@ import { JSONEditorValue } from '@/components/ui/JSONEditor';
 import AdditionalPropertyCard from '@/components/rjsf-components/AdditionalPropertyCard';
 import CodeEditorWidget from '@/components/ui/CodeEditorWidget';
 
-import staticBaseSchema from '@/FormSchemas/datasets/datasetSchema.json';
-import uiSchema from '@/FormSchemas/datasets/uischema.json';
+import datasetSchema from '@/FormSchemas/datasets/datasetSchema.json';
+import datasetUiSchema from '@/FormSchemas/datasets/uischema.json';
+import disastersDatasetSchema from '@/FormSchemas/disasters/datasetSchema.json';
+import disastersUiSchema from '@/FormSchemas/disasters/uischema.json';
 import { TestableUrlWidget } from '@/components/rjsf-components/TestableUrlWidget';
 import { RegexStringWidget } from '@/components/rjsf-components/RegexStringWidget';
 
 import { useTenants } from '@/hooks/useTenants';
+import { cfg } from '@/config/env';
 import { Form } from './rjsfTheme';
 
 // Lazy load JSONEditor - only needed when JSON tab is active
@@ -103,11 +106,27 @@ function DatasetIngestionForm({
   disableCollectionNameChange = false,
   defaultTemporalExtent = false,
 }: FormProps) {
+  const schemaSources = {
+    default: {
+      schema: datasetSchema,
+      uiSchema: datasetUiSchema,
+    },
+    disasters: {
+      schema: disastersDatasetSchema,
+      uiSchema: disastersUiSchema,
+    },
+  } as const;
+
+  const selectedSource =
+    schemaSources[cfg.DATASET_FORM_SCHEMA_PROFILE] || schemaSources.default;
+  const selectedSchema = selectedSource.schema;
+  const selectedUiSchema = selectedSource.uiSchema;
+
   const {
     schema: dynamicSchema,
     uiSchema: dynamicUiSchema,
     isLoading: isTenantsLoading,
-  } = useTenants(staticBaseSchema as JSONSchema7, uiSchema);
+  } = useTenants(selectedSchema as JSONSchema7, selectedUiSchema);
 
   const [activeTab, setActiveTab] = useState<string>('form');
   const [forceRenderKey, setForceRenderKey] = useState<number>(0);
@@ -118,7 +137,10 @@ function DatasetIngestionForm({
 
   const lockedUiSchema = dynamicUiSchema
     ? { ...dynamicUiSchema, ...lockedFormFields }
-    : { ...uiSchema, ...lockedFormFields };
+    : { ...selectedUiSchema, ...lockedFormFields };
+  const resolvedUiSchema = isEditMode
+    ? lockedUiSchema
+    : dynamicUiSchema || selectedUiSchema;
 
   const formScopedData = formData;
 
@@ -140,14 +162,6 @@ function DatasetIngestionForm({
           'https://stac-extensions.github.io/render/v1.0.0/schema.json',
           'https://stac-extensions.github.io/item-assets/v1.0.0/schema.json',
         ],
-        item_assets: {
-          cog_default: {
-            type: 'image/tiff; application=geotiff; profile=cloud-optimized',
-            roles: ['data', 'layer'],
-            title: 'Default COG Layer',
-            description: 'Cloud optimized default layer to display on map',
-          },
-        },
         providers: [
           {
             name: 'NASA VEDA',
@@ -264,9 +278,7 @@ function DatasetIngestionForm({
               <Form
                 key={forceRenderKey} // Forces re-render when data updates
                 schema={dynamicSchema as JSONSchema7}
-                uiSchema={
-                  isEditMode ? lockedUiSchema : dynamicUiSchema || uiSchema
-                }
+                uiSchema={resolvedUiSchema}
                 validator={validator}
                 customValidate={customValidate}
                 templates={{

--- a/components/rjsf-components/DiscoveryItemObjectFieldTemplate.tsx
+++ b/components/rjsf-components/DiscoveryItemObjectFieldTemplate.tsx
@@ -78,6 +78,10 @@ export default function DiscoveryItemObjectFieldTemplate<
           {renderGridRow(4)}{' '}
           {/* start_datetime, end_datetime, single_datetime */}
           {renderGridRow(5)} {/* id_regex, id_template, use_multithreading */}
+          {/* Render any additional env-configured rows */}
+          {itemUiGrid &&
+            itemUiGrid.length > 5 &&
+            itemUiGrid.slice(5).map((_, idx) => renderGridRow(5 + idx + 1))}
         </Panel>
       </Collapse>
     </>

--- a/components/rjsf-components/ObjectFieldTemplate.tsx
+++ b/components/rjsf-components/ObjectFieldTemplate.tsx
@@ -198,8 +198,10 @@ export default function ObjectFieldTemplate<
       (element.content?.props as { fieldPathId?: { $id?: string } })
         ?.fieldPathId?.$id || ''
     ).includes('renders');
+  // Apply discovery item template only to the array item object itself,
+  // not nested objects like discovery_items[].assets.
   const isDiscoveryItem =
-    fieldPathId.$id.startsWith('root_discovery_items_') &&
+    /^root_discovery_items_\d+$/.test(fieldPathId.$id) &&
     schema.type === 'object';
 
   if (isDiscoveryItem) {

--- a/config/env.ts
+++ b/config/env.ts
@@ -2,6 +2,7 @@
 // Switch via `NEXT_PUBLIC_APP_ENV` = 'local' | 'veda' | 'disasters'
 
 export type AppEnv = 'local' | 'eic' | 'disasters' | 'veda';
+export type DatasetFormSchemaProfile = 'default' | 'disasters';
 
 interface EnvConfig {
   OWNER: string;
@@ -13,6 +14,7 @@ interface EnvConfig {
   VEDA_BACKEND_URL: string;
   VEDA_PROD_BACKEND_URL: string;
   VEDA_TENANT_FILTER_FIELD?: string;
+  DATASET_FORM_SCHEMA_PROFILE: DatasetFormSchemaProfile;
 }
 
 const profiles: Record<AppEnv, EnvConfig> = {
@@ -25,6 +27,7 @@ const profiles: Record<AppEnv, EnvConfig> = {
     ADDITIONAL_LOGO: '',
     VEDA_BACKEND_URL: 'https://dev.openveda.cloud/api',
     VEDA_PROD_BACKEND_URL: 'https://staging.openveda.cloud/api',
+    DATASET_FORM_SCHEMA_PROFILE: 'disasters',
     VEDA_TENANT_FILTER_FIELD: 'local:tenant',
   },
   disasters: {
@@ -36,6 +39,7 @@ const profiles: Record<AppEnv, EnvConfig> = {
     ADDITIONAL_LOGO: 'disasters',
     VEDA_BACKEND_URL: 'https://staging.openveda.cloud/api',
     VEDA_PROD_BACKEND_URL: 'https://staging.openveda.cloud/api',
+    DATASET_FORM_SCHEMA_PROFILE: 'disasters',
   },
   veda: {
     OWNER: 'nasa-impact',
@@ -46,6 +50,7 @@ const profiles: Record<AppEnv, EnvConfig> = {
     ADDITIONAL_LOGO: '',
     VEDA_BACKEND_URL: 'https://staging.openveda.cloud/api',
     VEDA_PROD_BACKEND_URL: 'https://openveda.cloud/api',
+    DATASET_FORM_SCHEMA_PROFILE: 'default',
   },
   eic: {
     OWNER: 'nasa-impact',
@@ -56,6 +61,7 @@ const profiles: Record<AppEnv, EnvConfig> = {
     ADDITIONAL_LOGO: 'eic',
     VEDA_BACKEND_URL: 'https://eic-staging.staging.earth.gov/api',
     VEDA_PROD_BACKEND_URL: 'https://openveda.cloud/api',
+    DATASET_FORM_SCHEMA_PROFILE: 'default',
     VEDA_TENANT_FILTER_FIELD: 'eic:tenant',
   },
 };
@@ -67,6 +73,7 @@ const getAppEnv = (): AppEnv => {
   return 'local';
 };
 
-export const cfg: EnvConfig = profiles[getAppEnv()];
+export const APP_ENV: AppEnv = getAppEnv();
+export const cfg: EnvConfig = profiles[APP_ENV];
 export const VEDA_BACKEND_URL = cfg.VEDA_BACKEND_URL;
 export const VEDA_PROD_BACKEND_URL = cfg.VEDA_PROD_BACKEND_URL;

--- a/config/env.ts
+++ b/config/env.ts
@@ -27,7 +27,7 @@ const profiles: Record<AppEnv, EnvConfig> = {
     ADDITIONAL_LOGO: '',
     VEDA_BACKEND_URL: 'https://dev.openveda.cloud/api',
     VEDA_PROD_BACKEND_URL: 'https://staging.openveda.cloud/api',
-    DATASET_FORM_SCHEMA_PROFILE: 'disasters',
+    DATASET_FORM_SCHEMA_PROFILE: 'default',
     VEDA_TENANT_FILTER_FIELD: 'local:tenant',
   },
   disasters: {

--- a/utils/CleanAndPrettifyJson.ts
+++ b/utils/CleanAndPrettifyJson.ts
@@ -1,29 +1,23 @@
 type FormLikeData = {
-  renders?:
-    | string
-    | {
-        dashboard?: unknown;
-      }
-    | null;
+  renders?: string | Record<string, unknown> | null;
   [key: string]: unknown;
 };
 
 export const CleanAndPrettifyJSON = (data: FormLikeData): string => {
   const cleanedData: FormLikeData = { ...data };
 
-  if (
-    typeof cleanedData.renders === 'object' &&
-    cleanedData.renders !== null &&
-    typeof cleanedData.renders.dashboard === 'string' &&
-    cleanedData.renders.dashboard.trim() !== ''
-  ) {
-    try {
-      cleanedData.renders.dashboard = JSON.parse(cleanedData.renders.dashboard);
-    } catch {
-      console.warn(
-        "Invalid JSON in 'renders dashboard' field. Keeping as string."
-      );
-    }
+  if (typeof cleanedData.renders === 'object' && cleanedData.renders !== null) {
+    Object.entries(cleanedData.renders).forEach(([renderKey, renderValue]) => {
+      if (typeof renderValue === 'string' && renderValue.trim() !== '') {
+        try {
+          cleanedData.renders![renderKey] = JSON.parse(renderValue);
+        } catch {
+          console.warn(
+            `Invalid JSON in 'renders ${renderKey}' field. Keeping as string.`
+          );
+        }
+      }
+    });
   }
 
   return JSON.stringify(cleanedData, null, 2);

--- a/utils/CleanAndPrettifyJson.ts
+++ b/utils/CleanAndPrettifyJson.ts
@@ -7,10 +7,11 @@ export const CleanAndPrettifyJSON = (data: FormLikeData): string => {
   const cleanedData: FormLikeData = { ...data };
 
   if (typeof cleanedData.renders === 'object' && cleanedData.renders !== null) {
-    Object.entries(cleanedData.renders).forEach(([renderKey, renderValue]) => {
+    const renders = cleanedData.renders as Record<string, unknown>;
+    Object.entries(renders).forEach(([renderKey, renderValue]) => {
       if (typeof renderValue === 'string' && renderValue.trim() !== '') {
         try {
-          cleanedData.renders![renderKey] = JSON.parse(renderValue);
+          renders[renderKey] = JSON.parse(renderValue);
         } catch {
           console.warn(
             `Invalid JSON in 'renders ${renderKey}' field. Keeping as string.`

--- a/utils/CustomValidation.ts
+++ b/utils/CustomValidation.ts
@@ -13,22 +13,32 @@ export const customValidate: CustomValidator = (formData, errors) => {
   }
 
   try {
-    if (formData.renders && formData.renders.dashboard) {
-      const parsed = JSON.parse(formData.renders.dashboard);
-      if (
-        typeof parsed !== 'object' ||
-        parsed === null ||
-        Array.isArray(parsed)
-      ) {
-        errors.renders?.dashboard?.addError(
-          'Input must be a valid JSON object.'
-        );
-      }
+    if (formData.renders && typeof formData.renders === 'object') {
+      Object.entries(formData.renders).forEach(([renderKey, renderValue]) => {
+        if (typeof renderValue !== 'string' || renderValue.trim() === '') {
+          return;
+        }
+
+        try {
+          const parsed = JSON.parse(renderValue);
+          if (
+            typeof parsed !== 'object' ||
+            parsed === null ||
+            Array.isArray(parsed)
+          ) {
+            errors.renders?.[renderKey]?.addError(
+              'Input must be a valid JSON object.'
+            );
+          }
+        } catch {
+          errors.renders?.[renderKey]?.addError(
+            'Invalid JSON format. Please enter a valid JSON object.'
+          );
+        }
+      });
     }
   } catch {
-    errors.renders?.dashboard?.addError(
-      'Invalid JSON format. Please enter a valid JSON object.'
-    );
+    // Ignore unexpected renders shape errors; field-level validation above handles normal cases.
   }
 
   if (formData.temporal_extent) {


### PR DESCRIPTION
this work is to address #236 

## Summary
This PR adds a dedicated disasters dataset schema/UI profile and updates form behavior so disasters ingest JSON can be edited in both Form mode and Manual JSON mode without schema/UI mismatches.

## What Changed

- Introduced `config/env.ts` -driven schema selection for dataset forms (default vs disasters) based on the `DATASET_FORM_SCHEMA_PROFILE` value
- Added dedicated disasters schema and ui schemas under the `/formSchemas/disasters` directory.
- `DatasetIngestionForm.tsx` now loads the env specific schema as the new base schema

### UI Specific widget updates now that there are multiple schemas:
- Updated discovery item layout rendering to support dynamic additional grid rows.
- Fixed discovery item template detection so nested objects (like discovery_items.assets) do not render duplicate panels.
- Updated disasters renders behavior so that `dashboard` and `ColorIR` both render with the a code editor widget
- Removed automatic `item_assets.cog_default` initialization from `DatasetIngestionForm` default state so form defaults are not injected unexpectedly