### PR TITLE
update disasters configs to point to dev.disasters.openveda.cloud

### DIFF
--- a/config/env.ts
+++ b/config/env.ts
@@ -37,8 +37,8 @@ const profiles: Record<AppEnv, EnvConfig> = {
     AWS_REGION: 'us-west-2',
     NEXT_PUBLIC_AWS_S3_BUCKET_NAME: 'veda-thumbnails',
     ADDITIONAL_LOGO: 'disasters',
-    VEDA_BACKEND_URL: 'https://staging.openveda.cloud/api',
-    VEDA_PROD_BACKEND_URL: 'https://staging.openveda.cloud/api',
+    VEDA_BACKEND_URL: 'https://dev.disasters.openveda.cloud/api',
+    VEDA_PROD_BACKEND_URL: 'https://dev.disasters.openveda.cloud/api',
     DATASET_FORM_SCHEMA_PROFILE: 'disasters',
   },
   veda: {


### PR DESCRIPTION
The `/tenants/writable` and `/raster/cog/validate` endpoints are defined by `VEDA_BACKEND_URL`

the edit existing collection URL to make the GET for searching existing collections and PUT to update is controlled by `VEDA_PROD_BACKEND_URL`

This updates to use the dev.disasters apis