### PR TITLE
Feat/sanitize data on form load

### DIFF
--- a/__mocks__/stacCollectionResponse.ts
+++ b/__mocks__/stacCollectionResponse.ts
@@ -30,7 +30,7 @@ export const stacCollectionResponse = {
     },
   ],
   title: 'Test Collection 1 Full Details',
-  assets: null,
+  assets: {},
   extent: {
     spatial: {
       bbox: [[-96.71, 29.07, -94.41, 30.87]],

--- a/__tests__/playwright/EditExistingCollectionPageSanitzation.test.tsx
+++ b/__tests__/playwright/EditExistingCollectionPageSanitzation.test.tsx
@@ -94,7 +94,7 @@ test.describe('Edit Existing Collection Sanitization', () => {
       await expect(sanitizationModal).toBeVisible();
       await expect(
         sanitizationModal.getByText(
-          /The Existing Collection's STAC data has been updated as shown to match required metadata formats./i
+          /The Existing Collection's STAC metadata has been updated/i
         )
       ).toBeVisible();
 

--- a/__tests__/playwright/EditExistingCollectionPageSanitzation.test.tsx
+++ b/__tests__/playwright/EditExistingCollectionPageSanitzation.test.tsx
@@ -1,0 +1,154 @@
+import { expect, test } from '@/__tests__/playwright/setup-msw';
+import { HttpResponse } from 'msw';
+import { stacCollectionResponse } from '@/__mocks__/stacCollectionResponse';
+
+test.describe('Edit Existing Collection Sanitization', () => {
+  test('shows initial sanitization modal, reveals cleanup, enables submit, and sends sanitized PUT body', async ({
+    page,
+    http,
+    worker,
+  }) => {
+    const dirtyCollectionPayload = {
+      ...stacCollectionResponse,
+      assets: null,
+      item_assets: null,
+      summaries: null,
+      links: null,
+      keywords: null,
+      providers: null,
+      stac_extensions: null,
+      extent: {
+        ...stacCollectionResponse.extent,
+        temporal: {
+          interval: [['1998-01-01 00:00:00+00', null]],
+        },
+      },
+    };
+
+    const expectedInitialSanitizedPayload = {
+      ...stacCollectionResponse,
+      assets: {},
+      item_assets: {},
+      summaries: {},
+      links: [],
+      keywords: [],
+      providers: [],
+      stac_extensions: [],
+      extent: {
+        ...stacCollectionResponse.extent,
+        temporal: {
+          interval: [['1998-01-01T00:00:00+00:00', null]],
+        },
+      },
+    };
+
+    let putRequestIntercepted = false;
+    let putPayload: unknown;
+
+    await worker.use(
+      http.get('/api/existing-collection/:collectionId', ({ params }) => {
+        return HttpResponse.json({
+          ...dirtyCollectionPayload,
+          id: params.collectionId,
+        });
+      })
+    );
+
+    await page.route('**/api/existing-collection/*', async (route, request) => {
+      if (request.method() === 'PUT') {
+        putRequestIntercepted = true;
+        putPayload = request.postDataJSON();
+
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            githubURL: 'https://github.com/test/repo/pull/123',
+          }),
+        });
+      } else {
+        await route.fallback();
+      }
+    });
+
+    await test.step('Navigate to Edit Existing Collection Page', async () => {
+      await page.goto('/edit-existing-collection');
+    });
+
+    await expect(
+      page.getByRole('heading', { level: 3, name: 'Edit Existing Collection' })
+    ).toBeVisible();
+
+    await test.step('Select an existing collection', async () => {
+      await page
+        .locator('.ant-card')
+        .filter({ hasText: /test-collection-1/i })
+        .click();
+    });
+
+    const sanitizationModal = page.getByRole('dialog', {
+      name: /stac metadata format updates/i,
+    });
+
+    await test.step('Validate initial sanitization modal and diff content', async () => {
+      await expect(sanitizationModal).toBeVisible();
+      await expect(
+        sanitizationModal.getByText(
+          /The Existing Collection's STAC data has been updated as shown to match required metadata formats./i
+        )
+      ).toBeVisible();
+
+      // Ensure cleanup cues are visible in diff content.
+      await expect(sanitizationModal).toContainText(
+        '1998-01-01T00:00:00+00:00'
+      );
+    });
+
+    await test.step('Dismiss sanitization modal and verify JSON tab shows sanitized values', async () => {
+      await sanitizationModal.getByRole('button', { name: /^ok$/i }).click();
+      await expect(sanitizationModal).toBeHidden();
+
+      await page.getByRole('tab', { name: /manual json edit/i }).click();
+      await expect(page.getByTestId('json-editor')).toContainText(
+        '1998-01-01T00:00:00+00:00'
+      );
+      await expect(page.getByTestId('json-editor')).toContainText(
+        '"links": []'
+      );
+
+      await page.getByRole('tab', { name: /^form$/i }).click();
+
+      await expect(page.getByRole('button', { name: /submit/i })).toBeEnabled();
+    });
+
+    await test.step('Submit and verify sanitized payload in PUT body', async () => {
+      const requestPromise = page.waitForRequest(
+        (req) =>
+          req.url().includes('/api/existing-collection/') &&
+          req.method() === 'PUT'
+      );
+
+      await page.getByRole('button', { name: /submit/i }).click();
+
+      await expect(
+        page.getByRole('dialog', { name: /review changes/i })
+      ).toBeVisible();
+      await page.getByRole('button', { name: /confirm changes/i }).click();
+
+      await requestPromise;
+
+      expect(
+        putRequestIntercepted,
+        'PUT request should have been intercepted'
+      ).toBe(true);
+      expect(
+        putPayload,
+        'PUT body should contain the initial sanitized values'
+      ).toMatchObject(expectedInitialSanitizedPayload);
+      expect(putPayload).toHaveProperty(
+        'extent.temporal.interval.0.0',
+        '1998-01-01T00:00:00+00:00'
+      );
+    });
+  });
+});

--- a/components/ingestion/EditFormManager.tsx
+++ b/components/ingestion/EditFormManager.tsx
@@ -41,20 +41,44 @@ const EditFormManager: React.FC<EditFormManagerProps> = ({
     string,
     unknown
   > | null>(null);
+  const [isSanitizationModalVisible, setIsSanitizationModalVisible] =
+    useState(false);
+  const [sanitizedInitialFormData, setSanitizedInitialFormData] =
+    useState<Record<string, unknown> | null>(null);
+  const [hasInitializedOriginalData, setHasInitializedOriginalData] =
+    useState(false);
+  const shouldUseSanitizedCollectionFlow =
+    formType === 'collection' || formType === 'existingCollection';
 
   // When component mounts or formData is initially set, store it as the original state
+  // and check if sanitization would change the data for collection edit flows.
   useEffect(() => {
     if (
       formData &&
       Object.keys(formData).length > 0 &&
-      originalFormData &&
-      Object.keys(originalFormData).length === 0
+      !hasInitializedOriginalData
     ) {
-      setOriginalFormData(JSON.parse(JSON.stringify(formData)));
+      setHasInitializedOriginalData(true);
+      const raw = JSON.parse(JSON.stringify(formData));
+      setOriginalFormData(raw);
+      const sanitized = sanitizeFormData(raw);
+      if (
+        shouldUseSanitizedCollectionFlow &&
+        JSON.stringify(raw) !== JSON.stringify(sanitized)
+      ) {
+        setSanitizedInitialFormData(sanitized);
+        setIsSanitizationModalVisible(true);
+        setFormData(sanitized);
+      }
     }
-  }, [formData, originalFormData]);
+  }, [
+    formData,
+    hasInitializedOriginalData,
+    shouldUseSanitizedCollectionFlow,
+    setFormData,
+  ]);
 
-  // Compare current form data with original to determine if there are changes
+  // Compare current form data against the originally loaded payload.
   useEffect(() => {
     if (
       formData &&
@@ -65,7 +89,7 @@ const EditFormManager: React.FC<EditFormManagerProps> = ({
         JSON.stringify(formData) !== JSON.stringify(originalFormData);
       setDisabled(!hasChanges);
     }
-  }, [formData, originalFormData]);
+  }, [formData, originalFormData, shouldUseSanitizedCollectionFlow]);
 
   const {
     isCogValidationModalVisible,
@@ -109,17 +133,21 @@ const EditFormManager: React.FC<EditFormManagerProps> = ({
     setPendingFormData(null);
   };
 
+  const closeSanitizationModal = () => {
+    if (sanitizedInitialFormData) {
+      setFormData(sanitizedInitialFormData);
+    }
+    setIsSanitizationModalVisible(false);
+  };
+
   const submitFormData = (formData: Record<string, unknown>) => {
     setStatus('loadingGithub');
-
-    // Sanitize the form data to ensure STAC schema compliance
-    const sanitizedFormData = sanitizeFormData(formData);
 
     let url = 'api/create-ingest';
     let requestOptions: RequestInit;
 
     if (formType === 'existingCollection') {
-      const collectionId = sanitizedFormData.id as string;
+      const collectionId = formData.id as string;
       if (!collectionId) {
         console.error(
           'Collection ID is required for existing collection updates'
@@ -131,7 +159,7 @@ const EditFormManager: React.FC<EditFormManagerProps> = ({
       url = `/api/existing-collection/${encodeURIComponent(collectionId)}`;
       requestOptions = {
         method: 'PUT',
-        body: JSON.stringify(sanitizedFormData),
+        body: JSON.stringify(formData),
         headers: { 'Content-Type': 'application/json' },
       };
     } else {
@@ -141,7 +169,7 @@ const EditFormManager: React.FC<EditFormManagerProps> = ({
           gitRef,
           fileSha,
           filePath,
-          formData: sanitizedFormData,
+          formData,
         }),
         headers: { 'Content-Type': 'application/json' },
       };
@@ -224,6 +252,35 @@ const EditFormManager: React.FC<EditFormManagerProps> = ({
           />
         )}
       </Card>
+
+      <Modal
+        title="STAC Metadata Format Updates"
+        open={isSanitizationModalVisible}
+        onOk={closeSanitizationModal}
+        onCancel={closeSanitizationModal}
+        okText="OK"
+        cancelButtonProps={{ style: { display: 'none' } }}
+        width={1200}
+        destroyOnHidden={true}
+      >
+        <div style={{ marginBottom: 16 }}>
+          <Alert
+            message="The Existing Collection's STAC data has been updated as shown to match required metadata formats."
+            type="info"
+            showIcon
+          />
+        </div>
+        {sanitizedInitialFormData && (
+          <VirtualDiffViewer
+            oldValue={originalFormData}
+            newValue={sanitizedInitialFormData}
+            height={500}
+            showLineCount={true}
+            showObjectCountStats={false}
+            differOptions={{ showModifications: true }}
+          />
+        )}
+      </Modal>
 
       <Modal
         title="Review Changes"

--- a/components/ingestion/EditFormManager.tsx
+++ b/components/ingestion/EditFormManager.tsx
@@ -265,7 +265,7 @@ const EditFormManager: React.FC<EditFormManagerProps> = ({
       >
         <div style={{ marginBottom: 16 }}>
           <Alert
-            message="The Existing Collection's STAC data has been updated as shown to match required metadata formats."
+            message="The Existing Collection's STAC metadata has been updated in the form to match required format conventions before submission."
             type="info"
             showIcon
           />

--- a/components/ingestion/EditFormManager.tsx
+++ b/components/ingestion/EditFormManager.tsx
@@ -89,7 +89,7 @@ const EditFormManager: React.FC<EditFormManagerProps> = ({
         JSON.stringify(formData) !== JSON.stringify(originalFormData);
       setDisabled(!hasChanges);
     }
-  }, [formData, originalFormData, shouldUseSanitizedCollectionFlow]);
+  }, [formData, originalFormData]);
 
   const {
     isCogValidationModalVisible,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,12 +3,17 @@ import { defineConfig } from '@playwright/test';
 import dotenv from 'dotenv';
 dotenv.config();
 
+const webServerCommand = process.env.CI
+  ? 'NEXT_PUBLIC_DISABLE_AUTH=true NEXT_PUBLIC_APP_ENV=local NEXT_PUBLIC_MOCK_SCOPES="dataset:update stac:collection:update dataset:create" yarn start'
+  : 'NEXT_PUBLIC_DISABLE_AUTH=true NEXT_PUBLIC_APP_ENV=local NEXT_PUBLIC_MOCK_SCOPES="dataset:update stac:collection:update dataset:create" yarn dev';
+
 export default defineConfig({
   testDir: './__tests__/playwright',
   webServer: {
-    command:
-      'NEXT_PUBLIC_DISABLE_AUTH=true NEXT_PUBLIC_APP_ENV=local NEXT_PUBLIC_MOCK_SCOPES="dataset:update stac:collection:update dataset:create" yarn start',
+    command: webServerCommand,
     port: 3000,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000,
   },
   use: {
     baseURL: 'http://localhost:3000',


### PR DESCRIPTION
The Edit Collections flow has a feature to automatically sanitize old collection data that has null values or incorrect time formats.  However, during a call with the Disasters team, I noticed that that STAC metadata cleanup step didn't run until a user made changes and submitted the form.  That was awkward because a user never saw the changes and couldn't submit if there were no other changes to the metadata.  this now runs the function on load of the Collections editing forms.  A user sees a modal showing the automatic diff.  They can then close the modal and make any additional changes.  

<img width="1780" height="919" alt="Screenshot 2026-04-21 at 10 31 03 AM" src="https://github.com/user-attachments/assets/b4b08b09-ccc6-4165-b791-6084d632a77b" />
