### PR TITLE
Feat: Add structured logging

### DIFF
--- a/app/api/create-ingest/route.ts
+++ b/app/api/create-ingest/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { validateTenantAccess } from '@/lib/serverTenantValidation';
+import {
+  createRequestLogContext,
+  logRequestEnd,
+  logRequestError,
+  logRequestStart,
+  summarizeSession,
+} from '@/lib/structuredLogger';
 import { getTenantFieldKey } from '@/utils/tenantField';
 
 import CreatePR from '@/utils/githubUtils/CreatePR';
@@ -9,11 +16,15 @@ import UpdatePR from '@/utils/githubUtils/UpdatePR';
 type AllowedIngestionType = 'dataset' | 'collection';
 
 export async function POST(request: NextRequest) {
+  const logContext = createRequestLogContext(request, '/api/create-ingest');
+  logRequestStart(logContext);
+
   try {
     const body = await request.json();
 
     // Input validation
     if (!body || typeof body !== 'object') {
+      logRequestEnd(logContext, 400, { reason: 'invalid_request_body' });
       return NextResponse.json(
         { error: 'Invalid request body' },
         { status: 400 }
@@ -24,6 +35,7 @@ export async function POST(request: NextRequest) {
 
     // Validate required fields
     if (!data || typeof data !== 'object') {
+      logRequestEnd(logContext, 400, { reason: 'invalid_data_field' });
       return NextResponse.json(
         { error: 'Missing or invalid "data" field in the request body.' },
         { status: 400 }
@@ -31,6 +43,7 @@ export async function POST(request: NextRequest) {
     }
 
     if (!ingestionType || !['dataset', 'collection'].includes(ingestionType)) {
+      logRequestEnd(logContext, 400, { reason: 'invalid_ingestion_type' });
       return NextResponse.json(
         {
           error:
@@ -42,6 +55,7 @@ export async function POST(request: NextRequest) {
 
     // Validate userComment if provided
     if (userComment !== undefined && typeof userComment !== 'string') {
+      logRequestEnd(logContext, 400, { reason: 'invalid_user_comment' });
       return NextResponse.json(
         { error: 'Invalid "userComment" field. Must be a string.' },
         { status: 400 }
@@ -57,6 +71,10 @@ export async function POST(request: NextRequest) {
     if (tenant && tenant !== '' && tenant.toLowerCase() !== 'public') {
       const session = await auth();
       if (!session) {
+        logRequestEnd(logContext, 401, {
+          reason: 'missing_session_for_tenant_create',
+          tenant,
+        });
         return NextResponse.json(
           { error: 'Authentication required for tenant-specific requests' },
           { status: 401 }
@@ -65,6 +83,11 @@ export async function POST(request: NextRequest) {
 
       const tenantValidation = await validateTenantAccess(tenant, request);
       if (!tenantValidation.isValid) {
+        logRequestEnd(logContext, 403, {
+          reason: 'tenant_access_denied',
+          tenant,
+          ...summarizeSession(session),
+        });
         return NextResponse.json(
           {
             error:
@@ -82,12 +105,17 @@ export async function POST(request: NextRequest) {
       userComment
     );
 
+    logRequestEnd(logContext, 200, {
+      ingestionType: validatedIngestionType,
+      tenant: tenant ?? 'Public',
+    });
     return NextResponse.json({ githubURL: githubResponse });
   } catch (error) {
     if (error instanceof Error) {
+      logRequestError(logContext, error, { status: 400 });
       return NextResponse.json({ error: error.message }, { status: 400 });
     } else {
-      console.log(error);
+      logRequestError(logContext, error, { status: 500 });
       return NextResponse.json(
         { error: 'Internal Server Error' },
         { status: 500 }
@@ -97,9 +125,13 @@ export async function POST(request: NextRequest) {
 }
 
 export async function PUT(request: NextRequest) {
+  const logContext = createRequestLogContext(request, '/api/create-ingest');
+  logRequestStart(logContext);
+
   try {
     const session = await auth();
     if (!session) {
+      logRequestEnd(logContext, 401, { reason: 'missing_session' });
       return NextResponse.json(
         { error: 'Authentication required for updates' },
         { status: 401 }
@@ -107,6 +139,10 @@ export async function PUT(request: NextRequest) {
     }
 
     if (!session.scopes?.includes('dataset:update')) {
+      logRequestEnd(logContext, 403, {
+        reason: 'missing_scope_dataset_update',
+        ...summarizeSession(session),
+      });
       return NextResponse.json(
         { error: 'Insufficient permissions: dataset:update scope required' },
         { status: 403 }
@@ -121,6 +157,10 @@ export async function PUT(request: NextRequest) {
     const missingFields = requiredFields.filter((field) => !(field in body));
 
     if (missingFields.length > 0) {
+      logRequestEnd(logContext, 400, {
+        reason: 'missing_required_fields',
+        missingFieldCount: missingFields.length,
+      });
       return NextResponse.json(
         { error: `Missing required fields: ${missingFields.join(', ')}` },
         { status: 400 }
@@ -136,6 +176,10 @@ export async function PUT(request: NextRequest) {
     if (tenant && tenant !== '' && tenant.toLowerCase() !== 'public') {
       const session = await auth();
       if (!session) {
+        logRequestEnd(logContext, 401, {
+          reason: 'missing_session_for_tenant_update',
+          tenant,
+        });
         return NextResponse.json(
           { error: 'Authentication required for tenant-specific updates' },
           { status: 401 }
@@ -144,6 +188,11 @@ export async function PUT(request: NextRequest) {
 
       const tenantValidation = await validateTenantAccess(tenant, request);
       if (!tenantValidation.isValid) {
+        logRequestEnd(logContext, 403, {
+          reason: 'tenant_access_denied',
+          tenant,
+          ...summarizeSession(session),
+        });
         return NextResponse.json(
           {
             error:
@@ -157,15 +206,19 @@ export async function PUT(request: NextRequest) {
 
     await UpdatePR(gitRef, fileSha, filePath, formData);
 
+    logRequestEnd(logContext, 200, {
+      tenant: tenant ?? 'Public',
+    });
     return NextResponse.json(
       { message: 'Data updated successfully' },
       { status: 200 }
     );
   } catch (error) {
     if (error instanceof Error) {
+      logRequestError(logContext, error, { status: 400 });
       return NextResponse.json({ error: error.message }, { status: 400 });
     } else {
-      console.log(error);
+      logRequestError(logContext, error, { status: 500 });
       return NextResponse.json(
         { error: 'Internal Server Error' },
         { status: 500 }

--- a/app/api/existing-collection/[collectionId]/route.ts
+++ b/app/api/existing-collection/[collectionId]/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { validateTenantAccess } from '@/lib/serverTenantValidation';
+import {
+  createRequestLogContext,
+  logRequestEnd,
+  logRequestError,
+  logRequestStart,
+  summarizeSession,
+} from '@/lib/structuredLogger';
 import { VEDA_PROD_BACKEND_URL } from '@/config/env';
 import { getTenantFieldKey } from '@/utils/tenantField';
 
@@ -11,11 +18,18 @@ interface RouteParams {
 }
 
 export async function GET(request: NextRequest, { params }: RouteParams) {
+  const logContext = createRequestLogContext(
+    request,
+    '/api/existing-collection/[collectionId]'
+  );
+  logRequestStart(logContext);
+
   try {
     const tenantFieldKey = getTenantFieldKey();
 
     const session = await auth();
     if (!session) {
+      logRequestEnd(logContext, 401, { reason: 'missing_session' });
       return NextResponse.json(
         { error: 'Authentication required' },
         { status: 401 }
@@ -25,6 +39,10 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     const accessToken = (session as { accessToken?: string }).accessToken;
 
     if (!session.scopes?.includes('stac:collection:update')) {
+      logRequestEnd(logContext, 403, {
+        reason: 'missing_scope_stac_collection_update',
+        ...summarizeSession(session),
+      });
       return NextResponse.json(
         {
           error:
@@ -45,6 +63,10 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
 
     if (!stacResponse.ok) {
       const errorText = await stacResponse.text();
+      logRequestEnd(logContext, stacResponse.status, {
+        reason: 'downstream_collection_fetch_failed',
+        collectionId,
+      });
       return NextResponse.json(
         { error: `Collection not found: ${errorText}` },
         { status: stacResponse.status }
@@ -70,6 +92,11 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       );
 
       if (!tenantValidation.isValid) {
+        logRequestEnd(logContext, 403, {
+          reason: 'tenant_access_denied',
+          tenant: collectionTenant,
+          collectionId,
+        });
         return NextResponse.json(
           {
             error: `Access denied for collection from tenant: ${collectionTenant}`,
@@ -79,9 +106,10 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       }
     }
 
+    logRequestEnd(logContext, 200, { collectionId });
     return NextResponse.json(collectionData);
   } catch (error) {
-    console.error('Error fetching collection:', error);
+    logRequestError(logContext, error, { status: 500 });
     return NextResponse.json(
       { error: 'Failed to fetch collection' },
       { status: 500 }
@@ -90,11 +118,18 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
 }
 
 export async function PUT(request: NextRequest, { params }: RouteParams) {
+  const logContext = createRequestLogContext(
+    request,
+    '/api/existing-collection/[collectionId]'
+  );
+  logRequestStart(logContext);
+
   try {
     const tenantFieldKey = getTenantFieldKey();
 
     const session = await auth();
     if (!session) {
+      logRequestEnd(logContext, 401, { reason: 'missing_session' });
       return NextResponse.json(
         { error: 'Authentication required' },
         { status: 401 }
@@ -104,6 +139,10 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
     const accessToken = (session as { accessToken?: string }).accessToken;
 
     if (!session.scopes?.includes('stac:collection:update')) {
+      logRequestEnd(logContext, 403, {
+        reason: 'missing_scope_stac_collection_update',
+        ...summarizeSession(session),
+      });
       return NextResponse.json(
         {
           error:
@@ -125,6 +164,10 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
     });
 
     if (!existingResponse.ok) {
+      logRequestEnd(logContext, 404, {
+        reason: 'existing_collection_not_found',
+        collectionId,
+      });
       return NextResponse.json(
         { error: 'Collection not found' },
         { status: 404 }
@@ -148,6 +191,11 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
       );
 
       if (!tenantValidation.isValid) {
+        logRequestEnd(logContext, 403, {
+          reason: 'tenant_access_denied',
+          tenant: existingTenant,
+          collectionId,
+        });
         return NextResponse.json(
           {
             error: `Access denied for collection from tenant: ${existingTenant}`,
@@ -168,12 +216,10 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
 
     if (!updateResponse.ok) {
       const errorText = await updateResponse.text();
-      console.error('Existing collection PUT failed', {
+      logRequestEnd(logContext, updateResponse.status, {
+        reason: 'downstream_collection_put_failed',
         collectionId,
-        stacUrl,
-        status: updateResponse.status,
-        statusText: updateResponse.statusText,
-        responseBody: errorText,
+        downstreamStatus: updateResponse.status,
       });
       return NextResponse.json(
         {
@@ -191,14 +237,10 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
     }
 
     const updatedCollection = await updateResponse.json();
-    console.info('Existing collection PUT succeeded', {
-      collectionId,
-      stacUrl,
-      status: updateResponse.status,
-    });
+    logRequestEnd(logContext, 200, { collectionId });
     return NextResponse.json(updatedCollection);
   } catch (error) {
-    console.error('Error updating collection:', error);
+    logRequestError(logContext, error, { status: 500 });
     return NextResponse.json(
       {
         error: 'Failed to update collection',

--- a/app/api/existing-collection/route.ts
+++ b/app/api/existing-collection/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { getUserTenants } from '@/lib/serverTenantValidation';
+import {
+  createRequestLogContext,
+  logRequestEnd,
+  logRequestError,
+  logRequestStart,
+  summarizeSession,
+} from '@/lib/structuredLogger';
 import { VEDA_PROD_BACKEND_URL } from '@/config/env';
 import { getTenantFieldKey } from '@/utils/tenantField';
 
@@ -14,9 +21,16 @@ type StacCollectionsResponse = {
 };
 
 export async function GET(request: NextRequest) {
+  const logContext = createRequestLogContext(
+    request,
+    '/api/existing-collection'
+  );
+  logRequestStart(logContext);
+
   try {
     const session = await auth();
     if (!session) {
+      logRequestEnd(logContext, 401, { reason: 'missing_session' });
       return NextResponse.json(
         { error: 'Authentication required' },
         { status: 401 }
@@ -24,6 +38,10 @@ export async function GET(request: NextRequest) {
     }
 
     if (!session.scopes?.includes('stac:collection:update')) {
+      logRequestEnd(logContext, 403, {
+        reason: 'missing_scope_stac_collection_update',
+        ...summarizeSession(session),
+      });
       return NextResponse.json(
         {
           error:
@@ -58,6 +76,10 @@ export async function GET(request: NextRequest) {
       !isPublicFilter &&
       !userTenants.includes(normalizedTenantFilter)
     ) {
+      logRequestEnd(logContext, 403, {
+        reason: 'tenant_filter_access_denied',
+        tenant: normalizedTenantFilter,
+      });
       return NextResponse.json(
         { error: `Access denied for tenant: ${normalizedTenantFilter}` },
         { status: 403 }
@@ -83,6 +105,10 @@ export async function GET(request: NextRequest) {
     const stacResponse = await fetch(stacUrl);
     if (!stacResponse.ok) {
       const errorText = await stacResponse.text();
+      logRequestEnd(logContext, stacResponse.status, {
+        reason: 'downstream_stac_error',
+        downstreamStatus: stacResponse.status,
+      });
       return NextResponse.json(
         { error: `STAC API error: ${errorText}` },
         { status: stacResponse.status }
@@ -111,9 +137,15 @@ export async function GET(request: NextRequest) {
       });
     }
 
+    logRequestEnd(logContext, 200, {
+      tenantFilter: normalizedTenantFilter ?? null,
+      resultCount: Array.isArray(stacData.collections)
+        ? stacData.collections.length
+        : 0,
+    });
     return NextResponse.json(stacData);
   } catch (error) {
-    console.error('Error fetching collections:', error);
+    logRequestError(logContext, error, { status: 500 });
     return NextResponse.json(
       { error: 'Failed to fetch collections' },
       { status: 500 }

--- a/app/api/list-ingests/route.ts
+++ b/app/api/list-ingests/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { getUserTenants } from '@/lib/serverTenantValidation';
+import {
+  createRequestLogContext,
+  logRequestEnd,
+  logRequestError,
+  logRequestStart,
+  summarizeSession,
+} from '@/lib/structuredLogger';
 import { getTenantFieldKey } from '@/utils/tenantField';
 
 import ListPRs from '@/utils/githubUtils/ListPRs';
@@ -8,14 +15,22 @@ import ListPRs from '@/utils/githubUtils/ListPRs';
 type IngestionType = 'collection' | 'dataset';
 
 export async function GET(request: NextRequest) {
+  const logContext = createRequestLogContext(request, '/api/list-ingests');
+  logRequestStart(logContext);
+
   try {
     const session = await auth();
 
     if (!session) {
+      logRequestEnd(logContext, 401, { reason: 'missing_session' });
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
     if (!session.scopes?.includes('dataset:update')) {
+      logRequestEnd(logContext, 403, {
+        reason: 'missing_scope_dataset_update',
+        ...summarizeSession(session),
+      });
       return NextResponse.json(
         { error: 'Insufficient permissions: dataset:update scope required' },
         { status: 403 }
@@ -27,6 +42,7 @@ export async function GET(request: NextRequest) {
     const searchParams = request.nextUrl.searchParams;
     const ingestionType = searchParams.get('ingestionType') as IngestionType;
     if (!ingestionType) {
+      logRequestEnd(logContext, 400, { reason: 'missing_ingestion_type' });
       return NextResponse.json(
         { error: 'ingestionType parameter is required' },
         { status: 400 }
@@ -65,12 +81,18 @@ export async function GET(request: NextRequest) {
       };
     });
 
+    logRequestEnd(logContext, 200, {
+      ingestionType,
+      resultCount: tenantKeyedIngests.length,
+    });
     return NextResponse.json({ githubResponse: tenantKeyedIngests });
   } catch (error) {
-    console.error('Error in /api/list-ingest:', error);
     if (error instanceof Error) {
+      logRequestError(logContext, error, { status: 400 });
       return NextResponse.json({ error: error.message }, { status: 400 });
     }
+
+    logRequestError(logContext, error, { status: 500 });
     return NextResponse.json(
       { error: 'An unexpected error occurred on the server.' },
       { status: 500 }

--- a/app/api/retrieve-ingest/route.ts
+++ b/app/api/retrieve-ingest/route.ts
@@ -1,14 +1,25 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/auth';
+import {
+  createRequestLogContext,
+  logRequestEnd,
+  logRequestError,
+  logRequestStart,
+  summarizeSession,
+} from '@/lib/structuredLogger';
 
 import RetrieveJSON from '@/utils/githubUtils/RetrieveJSON';
 
 type IngestionType = 'collection' | 'dataset';
 
 export async function GET(request: NextRequest) {
+  const logContext = createRequestLogContext(request, '/api/retrieve-ingest');
+  logRequestStart(logContext);
+
   try {
     const session = await auth();
     if (!session) {
+      logRequestEnd(logContext, 401, { reason: 'missing_session' });
       return NextResponse.json(
         { error: 'Authentication required' },
         { status: 401 }
@@ -16,6 +27,10 @@ export async function GET(request: NextRequest) {
     }
 
     if (!session.scopes?.includes('dataset:update')) {
+      logRequestEnd(logContext, 403, {
+        reason: 'missing_scope_dataset_update',
+        ...summarizeSession(session),
+      });
       return NextResponse.json(
         { error: 'Insufficient permissions: dataset:update scope required' },
         { status: 403 }
@@ -27,6 +42,7 @@ export async function GET(request: NextRequest) {
     const ingestionType = searchParams.get('ingestionType') as IngestionType;
 
     if (!ref) {
+      logRequestEnd(logContext, 400, { reason: 'missing_ref' });
       return NextResponse.json(
         { error: 'Missing required query parameter: "ref".' },
         { status: 400 }
@@ -34,6 +50,7 @@ export async function GET(request: NextRequest) {
     }
 
     if (!ingestionType || !['dataset', 'collection'].includes(ingestionType)) {
+      logRequestEnd(logContext, 400, { reason: 'invalid_ingestion_type' });
       return NextResponse.json(
         {
           error:
@@ -47,6 +64,7 @@ export async function GET(request: NextRequest) {
     const content = response?.content;
 
     if (!content || typeof content !== 'object') {
+      logRequestEnd(logContext, 400, { reason: 'invalid_file_content' });
       return NextResponse.json(
         { error: 'Invalid file format. Expected a JSON object.' },
         { status: 400 }
@@ -59,6 +77,7 @@ export async function GET(request: NextRequest) {
         typeof datasetContent.collection !== 'string' ||
         datasetContent.collection.trim() === ''
       ) {
+        logRequestEnd(logContext, 400, { reason: 'invalid_dataset_content' });
         return NextResponse.json(
           {
             error:
@@ -73,6 +92,9 @@ export async function GET(request: NextRequest) {
         typeof collectionContent.id !== 'string' ||
         collectionContent.id.trim() === ''
       ) {
+        logRequestEnd(logContext, 400, {
+          reason: 'invalid_collection_content',
+        });
         return NextResponse.json(
           {
             error:
@@ -83,12 +105,14 @@ export async function GET(request: NextRequest) {
       }
     }
 
+    logRequestEnd(logContext, 200, { ingestionType, ref });
     return NextResponse.json(response);
   } catch (error) {
     if (error instanceof Error) {
+      logRequestError(logContext, error, { status: 400 });
       return NextResponse.json({ error: error.message }, { status: 400 });
     } else {
-      console.error('An unexpected error occurred:', error);
+      logRequestError(logContext, error, { status: 500 });
       return NextResponse.json(
         { error: 'An unexpected error occurred on the server.' },
         { status: 500 }

--- a/app/api/upload-url/route.ts
+++ b/app/api/upload-url/route.ts
@@ -1,10 +1,19 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { checkFileExists, generateSignedUrl } from '@/utils/s3';
+import {
+  createRequestLogContext,
+  logRequestEnd,
+  logRequestError,
+  logRequestStart,
+} from '@/lib/structuredLogger';
 
 const ALLOWED_FILE_TYPES = ['image/jpeg', 'image/png'];
 
 export async function POST(req: NextRequest) {
+  const logContext = createRequestLogContext(req, '/api/upload-url');
+  logRequestStart(logContext);
+
   try {
     const { NEXT_PUBLIC_AWS_S3_BUCKET_NAME: bucketName, AWS_REGION } =
       await import('@/config/env').then((m) => m.cfg);
@@ -12,6 +21,9 @@ export async function POST(req: NextRequest) {
     const { filename, filetype } = await req.json();
 
     if (!filename || !filetype) {
+      logRequestEnd(logContext, 400, {
+        reason: 'missing_filename_or_filetype',
+      });
       return NextResponse.json(
         { error: 'Missing filename or filetype' },
         { status: 400 }
@@ -19,6 +31,7 @@ export async function POST(req: NextRequest) {
     }
 
     if (!ALLOWED_FILE_TYPES.includes(filetype)) {
+      logRequestEnd(logContext, 400, { reason: 'invalid_file_type', filetype });
       return NextResponse.json(
         { error: 'Invalid file type. Only JPG and PNG are allowed.' },
         { status: 400 }
@@ -29,7 +42,10 @@ export async function POST(req: NextRequest) {
     try {
       fileExists = await checkFileExists(filename);
     } catch (error) {
-      console.error('Error checking file existence:', error);
+      logRequestError(logContext, error, {
+        status: 500,
+        reason: 'check_file_exists_failed',
+      });
       return NextResponse.json(
         { error: 'Failed to check file existence' },
         { status: 500 }
@@ -40,12 +56,19 @@ export async function POST(req: NextRequest) {
     try {
       signedUrl = await generateSignedUrl(filename, filetype);
     } catch (error) {
-      console.error('Error generating signed URL:', error);
+      logRequestError(logContext, error, {
+        status: 500,
+        reason: 'generate_signed_url_failed',
+      });
       return NextResponse.json(
         { error: 'Failed to generate upload URL' },
         { status: 500 }
       );
     }
+
+    logRequestEnd(logContext, 200, {
+      fileExists,
+    });
 
     return NextResponse.json({
       uploadUrl: signedUrl,
@@ -53,7 +76,7 @@ export async function POST(req: NextRequest) {
       fileExists,
     });
   } catch (error) {
-    console.error('Unexpected error:', error);
+    logRequestError(logContext, error, { status: 500 });
     return NextResponse.json(
       { error: 'Internal server error' },
       { status: 500 }

--- a/auth.ts
+++ b/auth.ts
@@ -4,6 +4,13 @@ import { JWT } from 'next-auth/jwt';
 import { NextResponse } from 'next/server';
 import { VEDA_BACKEND_URL } from '@/config/env';
 import { getRequiredRuntimeSecret } from '@/lib/runtimeSecrets';
+import {
+  createRequestLogContext,
+  logRequestEnd,
+  logRequestError,
+  logRequestStart,
+  logStructured,
+} from '@/lib/structuredLogger';
 
 const authDisabled = process.env.NEXT_PUBLIC_DISABLE_AUTH === 'true';
 
@@ -106,19 +113,17 @@ const fetchWritableTenants = async (accessToken: string): Promise<string[]> => {
     );
 
     if (!tenantsResponse.ok) {
-      console.warn(
-        'Failed to fetch allowed tenants during auth:',
-        tenantsResponse.status
-      );
+      logStructured('warn', 'auth.tenants.fetch_failed', {
+        status: tenantsResponse.status,
+      });
       return [];
     }
 
     const contentType = tenantsResponse.headers.get('content-type') || '';
     if (!contentType.toLowerCase().includes('application/json')) {
-      console.warn(
-        'Failed to fetch allowed tenants during auth: unexpected content-type',
-        contentType
-      );
+      logStructured('warn', 'auth.tenants.invalid_content_type', {
+        contentType,
+      });
       return [];
     }
 
@@ -135,17 +140,21 @@ const fetchWritableTenants = async (accessToken: string): Promise<string[]> => {
       )
     );
   } catch (error) {
-    console.warn('Failed to fetch allowed tenants during auth:', error);
+    logStructured('warn', 'auth.tenants.fetch_failed', {
+      message: error instanceof Error ? error.message : String(error),
+    });
     return normalizeTenants([]);
   }
 };
 
 const refreshAccessToken = async (token: AppJWT): Promise<AppJWT> => {
   if (!token.refreshToken) {
+    logStructured('warn', 'auth.token.refresh_missing_refresh_token');
     return { ...token, error: 'NoRefreshToken' };
   }
 
   try {
+    logStructured('info', 'auth.token.refresh_attempt');
     const issuer = process.env.NEXT_PUBLIC_KEYCLOAK_ISSUER!;
     const keycloakClientSecret = await getRequiredRuntimeSecret(
       'KEYCLOAK_CLIENT_SECRET'
@@ -166,6 +175,9 @@ const refreshAccessToken = async (token: AppJWT): Promise<AppJWT> => {
     });
 
     if (!response.ok) {
+      logStructured('warn', 'auth.token.refresh_failed', {
+        status: response.status,
+      });
       return { ...token, error: 'RefreshAccessTokenError' };
     }
 
@@ -179,6 +191,11 @@ const refreshAccessToken = async (token: AppJWT): Promise<AppJWT> => {
     const refreshedScopes = parseScopesFromAccessToken(refreshedAccessToken);
     const refreshedTenants = await fetchWritableTenants(refreshedAccessToken);
 
+    logStructured('info', 'auth.token.refresh_succeeded', {
+      scopeCount: refreshedScopes.length,
+      tenantCount: refreshedTenants.length,
+    });
+
     return {
       ...token,
       accessToken: refreshedAccessToken,
@@ -188,21 +205,23 @@ const refreshAccessToken = async (token: AppJWT): Promise<AppJWT> => {
       tenants: refreshedTenants,
       error: undefined,
     };
-  } catch {
+  } catch (error) {
+    logStructured('error', 'auth.token.refresh_exception', {
+      message: error instanceof Error ? error.message : String(error),
+    });
     return { ...token, error: 'RefreshAccessTokenError' };
   }
 };
 
 const initializeAuth = async (): Promise<void> => {
   if (authDisabled) {
-    // --- MOCKED AUTH FOR TESTING --- 🎭
-    console.log('🎭 Auth is disabled. Using mock session.');
-
     const mockTenants = getMockTenants();
-    console.log('🎭 Mock tenants:', mockTenants);
-
     const mockScopes = getMockScopes();
-    console.log('Mock scopes:', mockScopes);
+
+    logStructured('warn', 'auth.mock_mode_enabled', {
+      mockTenantCount: mockTenants.length,
+      mockScopeCount: mockScopes.length,
+    });
 
     const mockSession: Session & {
       scopes?: string[];
@@ -264,24 +283,32 @@ const initializeAuth = async (): Promise<void> => {
 
           try {
             if (process.env.NEXT_PUBLIC_DISABLE_AUTH === 'true') {
-              console.log(
-                'Skipping external tenants fetch in test environment'
-              );
               const mockTenants = process.env.NEXT_PUBLIC_MOCK_TENANTS;
               if (mockTenants && mockTenants.trim() !== '') {
                 customToken.tenants = normalizeTenants(mockTenants.split(','));
               } else {
                 customToken.tenants = normalizeTenants([]);
               }
+
+              logStructured('warn', 'auth.jwt.mock_tenants_applied', {
+                tenantCount: customToken.tenants.length,
+              });
             } else {
               customToken.tenants = await fetchWritableTenants(
                 account.access_token
               );
             }
           } catch (error) {
-            console.error('Error fetching allowed tenants during auth:', error);
+            logStructured('error', 'auth.jwt.tenants_fetch_exception', {
+              message: error instanceof Error ? error.message : String(error),
+            });
             customToken.tenants = normalizeTenants([]);
           }
+
+          logStructured('info', 'auth.jwt.initial_token_issued', {
+            scopeCount: customToken.scopes?.length ?? 0,
+            tenantCount: customToken.tenants?.length ?? 0,
+          });
 
           return customToken;
         }
@@ -316,22 +343,29 @@ const initializeAuth = async (): Promise<void> => {
         const mockTenants = process.env.NEXT_PUBLIC_MOCK_TENANTS;
         if (mockTenants && mockTenants.trim() !== '') {
           const tenants = normalizeTenants(mockTenants.split(','));
-          console.log('🎭 Overriding real tenants with mock tenants:', tenants);
           customSession.tenants = tenants;
+          logStructured('warn', 'auth.session.mock_tenants_overridden', {
+            tenantCount: tenants.length,
+          });
         }
 
         // Inject mock scopes from env if present
         const mockScopes = process.env.NEXT_PUBLIC_MOCK_SCOPES;
         if (mockScopes && mockScopes.trim() !== '') {
           const scopes = mockScopes.split(/[ ,]+/).filter(Boolean);
-          console.log('🎭 Overriding real scopes with mock scopes:', scopes);
           customSession.scopes = scopes;
+          logStructured('warn', 'auth.session.mock_scopes_overridden', {
+            scopeCount: scopes.length,
+          });
         } else if (customToken.scopes) {
           customSession.scopes = customToken.scopes as string[];
         }
 
         if (customToken.error) {
           customSession.error = customToken.error;
+          logStructured('warn', 'auth.session.token_error', {
+            error: customToken.error,
+          });
         }
 
         return customSession;
@@ -348,10 +382,18 @@ const initializeAuth = async (): Promise<void> => {
 
 const ensureAuthInitialized = async (): Promise<void> => {
   if (!authInitPromise) {
-    authInitPromise = initializeAuth().catch((error) => {
-      authInitPromise = null;
-      throw error;
-    });
+    logStructured('info', 'auth.initialize.start');
+    authInitPromise = initializeAuth()
+      .then(() => {
+        logStructured('info', 'auth.initialize.success');
+      })
+      .catch((error) => {
+        authInitPromise = null;
+        logStructured('error', 'auth.initialize.failure', {
+          message: error instanceof Error ? error.message : String(error),
+        });
+        throw error;
+      });
   }
 
   await authInitPromise;
@@ -364,14 +406,52 @@ const auth = async (): Promise<Session | null> => {
 
 const handlers = {
   GET: async (...args: Parameters<HandlersImpl['GET']>): Promise<Response> => {
-    await ensureAuthInitialized();
-    return handlersImpl.GET(...args);
+    const request = args[0] as Request;
+    const logContext = createRequestLogContext(
+      {
+        headers: request.headers,
+        method: request.method,
+        url: request.url,
+      },
+      '/api/auth/[...nextauth]'
+    );
+
+    logRequestStart(logContext);
+
+    try {
+      await ensureAuthInitialized();
+      const response = await handlersImpl.GET(...args);
+      logRequestEnd(logContext, response.status);
+      return response;
+    } catch (error) {
+      logRequestError(logContext, error, { status: 500 });
+      throw error;
+    }
   },
   POST: async (
     ...args: Parameters<HandlersImpl['POST']>
   ): Promise<Response> => {
-    await ensureAuthInitialized();
-    return handlersImpl.POST(...args);
+    const request = args[0] as Request;
+    const logContext = createRequestLogContext(
+      {
+        headers: request.headers,
+        method: request.method,
+        url: request.url,
+      },
+      '/api/auth/[...nextauth]'
+    );
+
+    logRequestStart(logContext);
+
+    try {
+      await ensureAuthInitialized();
+      const response = await handlersImpl.POST(...args);
+      logRequestEnd(logContext, response.status);
+      return response;
+    } catch (error) {
+      logRequestError(logContext, error, { status: 500 });
+      throw error;
+    }
   },
 };
 

--- a/lib/structuredLogger.ts
+++ b/lib/structuredLogger.ts
@@ -27,6 +27,29 @@ const MAX_REQUEST_ID_LENGTH = 128;
 const DEFAULT_PRODUCTION_LOG_LEVEL: LogLevel = 'warn';
 const DEFAULT_DEBUG_LOG_LEVEL: LogLevel = 'debug';
 
+interface RequestLogBasePayload {
+  requestId: string;
+  route: string;
+  method: string;
+  path: string;
+}
+
+interface RequestStartPayload extends RequestLogBasePayload {
+  [key: string]: JsonValue;
+}
+
+interface RequestEndPayload extends RequestLogBasePayload {
+  status: number;
+  durationMs: number;
+  [key: string]: JsonValue;
+}
+
+interface RequestErrorPayload extends RequestLogBasePayload {
+  durationMs: number;
+  error: { name: string; message: string; stack?: string };
+  [key: string]: JsonValue;
+}
+
 export interface RequestLogContext {
   requestId: string;
   route: string;
@@ -273,13 +296,14 @@ export const logRequestStart = (
     return;
   }
 
-  logStructured('info', 'api.request.start', {
+  const payload: RequestStartPayload = {
     requestId: context.requestId,
     route: context.route,
     method: context.method,
     path: context.path,
     ...details,
-  });
+  };
+  logStructured('info', 'api.request.start', payload);
 };
 
 export const logRequestEnd = (
@@ -293,7 +317,7 @@ export const logRequestEnd = (
 
   const level: LogLevel =
     status >= 500 ? 'error' : status >= 400 ? 'warn' : 'info';
-  logStructured(level, 'api.request.end', {
+  const payload: RequestEndPayload = {
     requestId: context.requestId,
     route: context.route,
     method: context.method,
@@ -301,7 +325,8 @@ export const logRequestEnd = (
     status,
     durationMs: Date.now() - context.startTime,
     ...details,
-  });
+  };
+  logStructured(level, 'api.request.end', payload);
 };
 
 export const logRequestError = (
@@ -309,7 +334,7 @@ export const logRequestError = (
   error: unknown,
   details: Record<string, JsonValue> = {}
 ): void => {
-  logStructured('error', 'api.request.error', {
+  const payload: RequestErrorPayload = {
     requestId: context.requestId,
     route: context.route,
     method: context.method,
@@ -317,5 +342,6 @@ export const logRequestError = (
     durationMs: Date.now() - context.startTime,
     error: toSerializableError(error),
     ...details,
-  });
+  };
+  logStructured('error', 'api.request.error', payload);
 };

--- a/lib/structuredLogger.ts
+++ b/lib/structuredLogger.ts
@@ -1,0 +1,273 @@
+import {
+  configureSync,
+  getConsoleSink,
+  getJsonLinesFormatter,
+  getLogger,
+  type LogLevel as LogTapeLevel,
+  type Logger,
+} from '@logtape/logtape';
+
+type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+const REQUEST_ID_HEADERS = [
+  'x-request-id',
+  'x-correlation-id',
+  'x-amzn-trace-id',
+];
+
+export interface RequestLogContext {
+  requestId: string;
+  route: string;
+  method: string;
+  path: string;
+  startTime: number;
+}
+
+interface HeaderLike {
+  get: (name: string) => string | null;
+}
+
+interface RequestLike {
+  headers?: HeaderLike;
+  method?: string;
+  nextUrl?: {
+    pathname?: string;
+  };
+  url?: string;
+}
+
+let isLogTapeConfigured = false;
+
+const ensureLogTapeConfigured = (): void => {
+  if (isLogTapeConfigured) {
+    return;
+  }
+
+  configureSync({
+    reset: true,
+    sinks: {
+      console: getConsoleSink({
+        formatter: getJsonLinesFormatter({
+          categorySeparator: '.',
+          properties: 'flatten',
+        }),
+      }),
+    },
+    loggers: [
+      // application logging policy
+      {
+        category: 'veda-ingest-ui',
+        lowestLevel: 'info',
+        sinks: ['console'],
+      },
+      // logtape library self-logging policy, with stricter filtering
+      {
+        category: ['logtape', 'meta'],
+        lowestLevel: 'warning',
+        sinks: ['console'],
+      },
+    ],
+  });
+
+  isLogTapeConfigured = true;
+};
+
+const getBaseLogger = (): Logger => {
+  ensureLogTapeConfigured();
+  return getLogger(['veda-ingest-ui', 'app']);
+};
+
+const getPathFromRequest = (request: RequestLike, fallback: string): string => {
+  if (request.nextUrl?.pathname) {
+    return request.nextUrl.pathname;
+  }
+
+  if (request.url) {
+    try {
+      return new URL(request.url).pathname;
+    } catch {
+      return fallback;
+    }
+  }
+
+  return fallback;
+};
+
+const createFallbackRequestId = (): string => {
+  if (
+    typeof crypto !== 'undefined' &&
+    typeof crypto.randomUUID === 'function'
+  ) {
+    return crypto.randomUUID();
+  }
+
+  return `req-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+};
+
+const pickRequestId = (headers?: HeaderLike): string => {
+  if (!headers) {
+    return createFallbackRequestId();
+  }
+
+  for (const headerName of REQUEST_ID_HEADERS) {
+    const value = headers.get(headerName);
+    if (value && value.trim() !== '') {
+      return value;
+    }
+  }
+
+  return createFallbackRequestId();
+};
+
+const toSerializableError = (
+  error: unknown
+): { name: string; message: string; stack?: string } => {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      stack: error.stack,
+    };
+  }
+
+  return {
+    name: 'UnknownError',
+    message: typeof error === 'string' ? error : JSON.stringify(error),
+  };
+};
+
+const toLogTapeLevel = (level: LogLevel): LogTapeLevel => {
+  if (level === 'warn') {
+    return 'warning';
+  }
+
+  return level;
+};
+
+export const logStructured = (
+  level: LogLevel,
+  event: string,
+  details: Record<string, JsonValue> = {}
+): void => {
+  const logger = getBaseLogger();
+  const payload = {
+    event,
+    ...details,
+  };
+
+  const logTapeLevel = toLogTapeLevel(level);
+
+  switch (logTapeLevel) {
+    case 'debug':
+      logger.debug('{event}', payload);
+      break;
+    case 'info':
+      logger.info('{event}', payload);
+      break;
+    case 'warning':
+      logger.warn('{event}', payload);
+      break;
+    case 'error':
+      logger.error('{event}', payload);
+      break;
+    default:
+      logger.info('{event}', payload);
+      break;
+  }
+};
+
+export const createRequestLogContext = (
+  request: RequestLike,
+  route: string
+): RequestLogContext => {
+  return {
+    requestId: pickRequestId(request.headers),
+    route,
+    method: request.method ?? 'UNKNOWN',
+    path: getPathFromRequest(request, route),
+    startTime: Date.now(),
+  };
+};
+
+export const summarizeSession = (
+  session: unknown
+): Record<string, JsonValue> => {
+  if (!session || typeof session !== 'object') {
+    return { hasSession: false };
+  }
+
+  const sessionRecord = session as {
+    scopes?: unknown;
+    tenants?: unknown;
+    accessToken?: unknown;
+    error?: unknown;
+  };
+
+  return {
+    hasSession: true,
+    scopeCount: Array.isArray(sessionRecord.scopes)
+      ? sessionRecord.scopes.length
+      : 0,
+    tenantCount: Array.isArray(sessionRecord.tenants)
+      ? sessionRecord.tenants.length
+      : 0,
+    hasAccessToken: typeof sessionRecord.accessToken === 'string',
+    authError:
+      typeof sessionRecord.error === 'string' ? sessionRecord.error : null,
+  };
+};
+
+export const logRequestStart = (
+  context: RequestLogContext,
+  details: Record<string, JsonValue> = {}
+): void => {
+  logStructured('info', 'api.request.start', {
+    requestId: context.requestId,
+    route: context.route,
+    method: context.method,
+    path: context.path,
+    ...details,
+  });
+};
+
+export const logRequestEnd = (
+  context: RequestLogContext,
+  status: number,
+  details: Record<string, JsonValue> = {}
+): void => {
+  const level: LogLevel =
+    status >= 500 ? 'error' : status >= 400 ? 'warn' : 'info';
+  logStructured(level, 'api.request.end', {
+    requestId: context.requestId,
+    route: context.route,
+    method: context.method,
+    path: context.path,
+    status,
+    durationMs: Date.now() - context.startTime,
+    ...details,
+  });
+};
+
+export const logRequestError = (
+  context: RequestLogContext,
+  error: unknown,
+  details: Record<string, JsonValue> = {}
+): void => {
+  logStructured('error', 'api.request.error', {
+    requestId: context.requestId,
+    route: context.route,
+    method: context.method,
+    path: context.path,
+    durationMs: Date.now() - context.startTime,
+    error: toSerializableError(error),
+    ...details,
+  });
+};

--- a/lib/structuredLogger.ts
+++ b/lib/structuredLogger.ts
@@ -23,6 +23,8 @@ const REQUEST_ID_HEADERS = [
   'x-amzn-trace-id',
 ];
 
+const MAX_REQUEST_ID_LENGTH = 128;
+
 export interface RequestLogContext {
   requestId: string;
   route: string;
@@ -112,6 +114,18 @@ const createFallbackRequestId = (): string => {
   return `req-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
 };
 
+const sanitizeRequestId = (value: string): string | null => {
+  const normalized = value
+    .trim()
+    // Remove control characters that can break one-line JSON logs.
+    .replace(/[\u0000-\u001F\u007F]/g, '')
+    // Keep a conservative set of safe characters for IDs.
+    .replace(/[^a-zA-Z0-9._:/-]/g, '')
+    .slice(0, MAX_REQUEST_ID_LENGTH);
+
+  return normalized === '' ? null : normalized;
+};
+
 const pickRequestId = (headers?: HeaderLike): string => {
   if (!headers) {
     return createFallbackRequestId();
@@ -120,7 +134,10 @@ const pickRequestId = (headers?: HeaderLike): string => {
   for (const headerName of REQUEST_ID_HEADERS) {
     const value = headers.get(headerName);
     if (value && value.trim() !== '') {
-      return value;
+      const sanitized = sanitizeRequestId(value);
+      if (sanitized) {
+        return sanitized;
+      }
     }
   }
 
@@ -140,7 +157,16 @@ const toSerializableError = (
 
   return {
     name: 'UnknownError',
-    message: typeof error === 'string' ? error : JSON.stringify(error),
+    message:
+      typeof error === 'string'
+        ? error
+        : (() => {
+            try {
+              return JSON.stringify(error);
+            } catch {
+              return '[unserializable-error]';
+            }
+          })(),
   };
 };
 

--- a/lib/structuredLogger.ts
+++ b/lib/structuredLogger.ts
@@ -58,15 +58,15 @@ const parseLogLevelFromEnv = (): LogLevel | null => {
     return null;
   }
 
-  if (raw === 'debug' || raw === 'info' || raw === 'warn' || raw === 'error') {
-    return raw;
-  }
+  const aliases: Record<string, LogLevel> = {
+    debug: 'debug',
+    info: 'info',
+    warn: 'warn',
+    warning: 'warn',
+    error: 'error',
+  };
 
-  if (raw === 'warning') {
-    return 'warn';
-  }
-
-  return null;
+  return aliases[raw] ?? null;
 };
 
 const configuredLogLevel: LogLevel = isDebugLoggingEnabled

--- a/lib/structuredLogger.ts
+++ b/lib/structuredLogger.ts
@@ -24,6 +24,8 @@ const REQUEST_ID_HEADERS = [
 ];
 
 const MAX_REQUEST_ID_LENGTH = 128;
+const DEFAULT_PRODUCTION_LOG_LEVEL: LogLevel = 'warn';
+const DEFAULT_DEBUG_LOG_LEVEL: LogLevel = 'debug';
 
 export interface RequestLogContext {
   requestId: string;
@@ -47,6 +49,29 @@ interface RequestLike {
 }
 
 let isLogTapeConfigured = false;
+const isDebugLoggingEnabled = process.env.ENABLE_DEBUG_LOGGING === 'true';
+
+const parseLogLevelFromEnv = (): LogLevel | null => {
+  const raw = process.env.LOG_LEVEL?.trim().toLowerCase();
+
+  if (!raw) {
+    return null;
+  }
+
+  if (raw === 'debug' || raw === 'info' || raw === 'warn' || raw === 'error') {
+    return raw;
+  }
+
+  if (raw === 'warning') {
+    return 'warn';
+  }
+
+  return null;
+};
+
+const configuredLogLevel: LogLevel = isDebugLoggingEnabled
+  ? (parseLogLevelFromEnv() ?? DEFAULT_DEBUG_LOG_LEVEL)
+  : DEFAULT_PRODUCTION_LOG_LEVEL;
 
 const ensureLogTapeConfigured = (): void => {
   if (isLogTapeConfigured) {
@@ -67,7 +92,7 @@ const ensureLogTapeConfigured = (): void => {
       // application logging policy
       {
         category: 'veda-ingest-ui',
-        lowestLevel: 'info',
+        lowestLevel: toLogTapeLevel(configuredLogLevel),
         sinks: ['console'],
       },
       // logtape library self-logging policy, with stricter filtering
@@ -178,6 +203,8 @@ const toLogTapeLevel = (level: LogLevel): LogTapeLevel => {
   return level;
 };
 
+const shouldLogSuccessfulRequest = (): boolean => isDebugLoggingEnabled;
+
 export const logStructured = (
   level: LogLevel,
   event: string,
@@ -255,6 +282,10 @@ export const logRequestStart = (
   context: RequestLogContext,
   details: Record<string, JsonValue> = {}
 ): void => {
+  if (!shouldLogSuccessfulRequest()) {
+    return;
+  }
+
   logStructured('info', 'api.request.start', {
     requestId: context.requestId,
     route: context.route,
@@ -269,6 +300,10 @@ export const logRequestEnd = (
   status: number,
   details: Record<string, JsonValue> = {}
 ): void => {
+  if (status < 400 && !shouldLogSuccessfulRequest()) {
+    return;
+  }
+
   const level: LogLevel =
     status >= 500 ? 'error' : status >= 400 ? 'warn' : 'info';
   logStructured(level, 'api.request.end', {

--- a/lib/structuredLogger.ts
+++ b/lib/structuredLogger.ts
@@ -79,7 +79,6 @@ const ensureLogTapeConfigured = (): void => {
   }
 
   configureSync({
-    reset: true,
     sinks: {
       console: getConsoleSink({
         formatter: getJsonLinesFormatter({

--- a/lib/structuredLogger.ts
+++ b/lib/structuredLogger.ts
@@ -48,7 +48,6 @@ interface RequestLike {
   url?: string;
 }
 
-let isLogTapeConfigured = false;
 const isDebugLoggingEnabled = process.env.ENABLE_DEBUG_LOGGING === 'true';
 
 const parseLogLevelFromEnv = (): LogLevel | null => {
@@ -73,43 +72,40 @@ const configuredLogLevel: LogLevel = isDebugLoggingEnabled
   ? (parseLogLevelFromEnv() ?? DEFAULT_DEBUG_LOG_LEVEL)
   : DEFAULT_PRODUCTION_LOG_LEVEL;
 
-const ensureLogTapeConfigured = (): void => {
-  if (isLogTapeConfigured) {
-    return;
+const toLogTapeLevel = (level: LogLevel): LogTapeLevel => {
+  if (level === 'warn') {
+    return 'warning';
   }
 
-  configureSync({
-    sinks: {
-      console: getConsoleSink({
-        formatter: getJsonLinesFormatter({
-          categorySeparator: '.',
-          properties: 'flatten',
-        }),
+  return level;
+};
+
+configureSync({
+  sinks: {
+    console: getConsoleSink({
+      formatter: getJsonLinesFormatter({
+        categorySeparator: '.',
+        properties: 'flatten',
       }),
+    }),
+  },
+  loggers: [
+    // application logging policy
+    {
+      category: 'veda-ingest-ui',
+      lowestLevel: toLogTapeLevel(configuredLogLevel),
+      sinks: ['console'],
     },
-    loggers: [
-      // application logging policy
-      {
-        category: 'veda-ingest-ui',
-        lowestLevel: toLogTapeLevel(configuredLogLevel),
-        sinks: ['console'],
-      },
-      // logtape library self-logging policy, with stricter filtering
-      {
-        category: ['logtape', 'meta'],
-        lowestLevel: 'warning',
-        sinks: ['console'],
-      },
-    ],
-  });
+    // logtape library self-logging policy, with stricter filtering
+    {
+      category: ['logtape', 'meta'],
+      lowestLevel: 'warning',
+      sinks: ['console'],
+    },
+  ],
+});
 
-  isLogTapeConfigured = true;
-};
-
-const getBaseLogger = (): Logger => {
-  ensureLogTapeConfigured();
-  return getLogger(['veda-ingest-ui', 'app']);
-};
+const getBaseLogger = (): Logger => getLogger(['veda-ingest-ui', 'app']);
 
 const getPathFromRequest = (request: RequestLike, fallback: string): string => {
   if (request.nextUrl?.pathname) {
@@ -192,14 +188,6 @@ const toSerializableError = (
             }
           })(),
   };
-};
-
-const toLogTapeLevel = (level: LogLevel): LogTapeLevel => {
-  if (level === 'warn') {
-    return 'warning';
-  }
-
-  return level;
 };
 
 const shouldLogSuccessfulRequest = (): boolean => isDebugLoggingEnabled;

--- a/lib/structuredLogger.ts
+++ b/lib/structuredLogger.ts
@@ -50,11 +50,7 @@ interface RequestErrorPayload extends RequestLogBasePayload {
   [key: string]: JsonValue;
 }
 
-export interface RequestLogContext {
-  requestId: string;
-  route: string;
-  method: string;
-  path: string;
+export interface RequestLogContext extends RequestLogBasePayload {
   startTime: number;
 }
 
@@ -73,6 +69,14 @@ interface RequestLike {
 
 const isDebugLoggingEnabled = process.env.ENABLE_DEBUG_LOGGING === 'true';
 
+const LOG_LEVEL_ALIASES: Record<string, LogLevel> = {
+  debug: 'debug',
+  info: 'info',
+  warn: 'warn',
+  warning: 'warn',
+  error: 'error',
+};
+
 const parseLogLevelFromEnv = (): LogLevel | null => {
   const raw = process.env.LOG_LEVEL?.trim().toLowerCase();
 
@@ -80,15 +84,7 @@ const parseLogLevelFromEnv = (): LogLevel | null => {
     return null;
   }
 
-  const aliases: Record<string, LogLevel> = {
-    debug: 'debug',
-    info: 'info',
-    warn: 'warn',
-    warning: 'warn',
-    error: 'error',
-  };
-
-  return aliases[raw] ?? null;
+  return LOG_LEVEL_ALIASES[raw] ?? null;
 };
 
 const configuredLogLevel: LogLevel = isDebugLoggingEnabled
@@ -128,7 +124,7 @@ configureSync({
   ],
 });
 
-const getBaseLogger = (): Logger => getLogger(['veda-ingest-ui', 'app']);
+const baseLogger: Logger = getLogger(['veda-ingest-ui', 'app']);
 
 const getPathFromRequest = (request: RequestLike, fallback: string): string => {
   if (request.nextUrl?.pathname) {
@@ -213,14 +209,11 @@ const toSerializableError = (
   };
 };
 
-const shouldLogSuccessfulRequest = (): boolean => isDebugLoggingEnabled;
-
 export const logStructured = (
   level: LogLevel,
   event: string,
   details: Record<string, JsonValue> = {}
 ): void => {
-  const logger = getBaseLogger();
   const payload = {
     event,
     ...details,
@@ -230,19 +223,19 @@ export const logStructured = (
 
   switch (logTapeLevel) {
     case 'debug':
-      logger.debug('{event}', payload);
+      baseLogger.debug('{event}', payload);
       break;
     case 'info':
-      logger.info('{event}', payload);
+      baseLogger.info('{event}', payload);
       break;
     case 'warning':
-      logger.warn('{event}', payload);
+      baseLogger.warn('{event}', payload);
       break;
     case 'error':
-      logger.error('{event}', payload);
+      baseLogger.error('{event}', payload);
       break;
     default:
-      logger.info('{event}', payload);
+      baseLogger.info('{event}', payload);
       break;
   }
 };
@@ -288,19 +281,25 @@ export const summarizeSession = (
   };
 };
 
+const contextToBasePayload = (
+  context: RequestLogContext
+): RequestLogBasePayload => ({
+  requestId: context.requestId,
+  route: context.route,
+  method: context.method,
+  path: context.path,
+});
+
 export const logRequestStart = (
   context: RequestLogContext,
   details: Record<string, JsonValue> = {}
 ): void => {
-  if (!shouldLogSuccessfulRequest()) {
+  if (!isDebugLoggingEnabled) {
     return;
   }
 
   const payload: RequestStartPayload = {
-    requestId: context.requestId,
-    route: context.route,
-    method: context.method,
-    path: context.path,
+    ...contextToBasePayload(context),
     ...details,
   };
   logStructured('info', 'api.request.start', payload);
@@ -311,17 +310,14 @@ export const logRequestEnd = (
   status: number,
   details: Record<string, JsonValue> = {}
 ): void => {
-  if (status < 400 && !shouldLogSuccessfulRequest()) {
+  if (status < 400 && !isDebugLoggingEnabled) {
     return;
   }
 
   const level: LogLevel =
     status >= 500 ? 'error' : status >= 400 ? 'warn' : 'info';
   const payload: RequestEndPayload = {
-    requestId: context.requestId,
-    route: context.route,
-    method: context.method,
-    path: context.path,
+    ...contextToBasePayload(context),
     status,
     durationMs: Date.now() - context.startTime,
     ...details,
@@ -335,10 +331,7 @@ export const logRequestError = (
   details: Record<string, JsonValue> = {}
 ): void => {
   const payload: RequestErrorPayload = {
-    requestId: context.requestId,
-    route: context.route,
-    method: context.method,
-    path: context.path,
+    ...contextToBasePayload(context),
     durationMs: Date.now() - context.startTime,
     error: toSerializableError(error),
     ...details,

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@aws-sdk/client-secrets-manager": "^3.1019.0",
     "@aws-sdk/client-sts": "^3.1020.0",
     "@aws-sdk/s3-request-presigner": "^3.1020.0",
+    "@logtape/logtape": "^2.0.5",
     "@octokit/auth-app": "^7.1.3",
     "@octokit/rest": "^21.0.2",
     "@rjsf/antd": "^6.2.5",

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,5 +1,11 @@
 import { auth } from '@/auth';
 import { NextResponse, NextRequest } from 'next/server';
+import {
+  createRequestLogContext,
+  logRequestEnd,
+  logRequestStart,
+  summarizeSession,
+} from '@/lib/structuredLogger';
 
 const DISABLE_AUTH = process.env.NEXT_PUBLIC_DISABLE_AUTH === 'true';
 
@@ -108,18 +114,21 @@ function isRouteAllowed(pathname: string, permissionLevel: string) {
 }
 
 export async function proxy(request: NextRequest) {
+  const logContext = createRequestLogContext(request, 'proxy');
+  logRequestStart(logContext, { target: 'authz-gate' });
+
   // Security: Ensure auth is never disabled in production
   if (DISABLE_AUTH && process.env.NODE_ENV === 'production') {
-    console.error(
-      'SECURITY WARNING: Authentication cannot be disabled in production'
-    );
+    logRequestEnd(logContext, 500, {
+      reason: 'auth_disabled_in_production',
+    });
     throw new Error('Authentication cannot be disabled in production');
   }
 
   if (DISABLE_AUTH) {
-    console.warn(
-      'WARNING: Authentication is disabled for development - middleware skipping auth checks'
-    );
+    logRequestEnd(logContext, 200, {
+      reason: 'auth_disabled_in_non_production',
+    });
     return NextResponse.next();
   }
 
@@ -132,6 +141,11 @@ export async function proxy(request: NextRequest) {
   if (!isRouteAllowed(pathname, permissionLevel)) {
     if (pathname.startsWith('/api/')) {
       const status = permissionLevel === 'unauthenticated' ? 401 : 403;
+      logRequestEnd(logContext, status, {
+        reason: 'route_not_allowed',
+        permissionLevel,
+        ...summarizeSession(session),
+      });
       return new NextResponse(
         permissionLevel === 'unauthenticated' ? 'Unauthorized' : 'Forbidden',
         { status }
@@ -139,10 +153,21 @@ export async function proxy(request: NextRequest) {
     } else {
       const redirectUrl =
         permissionLevel === 'unauthenticated' ? '/login' : '/unauthorized';
+      logRequestEnd(logContext, 302, {
+        reason: 'route_not_allowed_redirect',
+        permissionLevel,
+        redirectUrl,
+        ...summarizeSession(session),
+      });
       return NextResponse.redirect(new URL(redirectUrl, request.url));
     }
   }
 
+  logRequestEnd(logContext, 200, {
+    reason: 'route_allowed',
+    permissionLevel,
+    ...summarizeSession(session),
+  });
   return NextResponse.next();
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2232,6 +2232,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@logtape/logtape@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "@logtape/logtape@npm:2.0.5"
+  checksum: 10c0/4a1100d39fcf38c60a56c63932775380e89c9b8de28edc85842a677701483101e223ca5c5b1db1e4f3763707bbb67e0ef383228818f1fa62265495fcebffb740
+  languageName: node
+  linkType: hard
+
 "@mswjs/cookies@npm:^1.1.0":
   version: 1.1.1
   resolution: "@mswjs/cookies@npm:1.1.1"
@@ -11669,6 +11676,7 @@ __metadata:
     "@aws-sdk/client-secrets-manager": "npm:^3.1019.0"
     "@aws-sdk/client-sts": "npm:^3.1020.0"
     "@aws-sdk/s3-request-presigner": "npm:^3.1020.0"
+    "@logtape/logtape": "npm:^2.0.5"
     "@octokit/auth-app": "npm:^7.1.3"
     "@octokit/rest": "npm:^21.0.2"
     "@octokit/types": "npm:^13.6.2"


### PR DESCRIPTION
This is the first step for #246 

This pulls in the logtape library and replaces the existing  ad-hoc console writing with the structured logging.  a follow up will be to look at the logs in aws and put together detailed runbooks


What the Structured Logger Does
Key Details:

1. JSON-lines formatted output – Each log entry is a single JSON object on one line, compatible with CloudWatch log parsing and aggregation.
2. Request lifecycle tracking – Associates all logs with a request ID extracted from HTTP headers (x-request-id, x-correlation-id, x-amzn-trace-id).
3. Verbose Logging controled by Env Variable– Production defaults to warn level; verbose request logging requires `ENABLE_DEBUG_LOGGING=true.`
4. Safe serialization – Request IDs are sanitized to prevent log injection; errors are safely serialized even if they contain unserializable values.
5. Session summaries –  auth/session data filtered into safe summaries (scope counts, tenant counts, token presence) without exposing sensitive values.


How It Works
Log level is determined at startup based on `ENABLE_DEBUG_LOGGING` and optional `LOG_LEVEL` env variable.
Each request creates a RequestLogContext with a sanitized request ID and timing info:

## Example
```javascript
const logContext = createRequestLogContext(request, '/api/create-ingest');
logRequestStart(logContext);
// ... handle request ...
logRequestEnd(logContext, 200, { details });
```

Example Output (CloudWatch)
```json
{"event":"api.request.start","requestId":"x-abc123","route":"/api/create-ingest","method":"POST","path":"/api/create-ingest"}
{"event":"api.request.end","requestId":"x-abc123","route":"/api/create-ingest","status":200,"durationMs":145,"ingestionType":"dataset","tenant":"Public"}
{"event":"api.request.error","requestId":"x-abc123","route":"/api/create-ingest","error":{"name":"ValidationError","message":"Invalid field"},"status":400}
```



