### PR TITLE
Fix: initialize selectedBands state with metadata

### DIFF
--- a/__tests__/hooks/useCOGViewer.test.tsx
+++ b/__tests__/hooks/useCOGViewer.test.tsx
@@ -72,7 +72,7 @@ describe('useCOGViewer', () => {
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
       expect(result.current.metadata).toEqual(mockInfoData);
-      expect(result.current.selectedBands).toEqual([1]);
+      expect(result.current.selectedBands).toEqual([1, 2, 3]);
       expect(result.current.tileUrl).toBe(mockTileJsonData.tiles[0]);
     });
   });
@@ -107,6 +107,91 @@ describe('useCOGViewer', () => {
     const tileUrlFetchCall = vi.mocked(fetch).mock.calls[1][0];
     expect(tileUrlFetchCall).toContain('&bidx=3&bidx=2&bidx=1');
     expect(tileUrlFetchCall).toContain('&colormap_name=pretty_color');
+  });
+
+  it('should default to the first 3 bands when metadata has more than 3 bands', async () => {
+    const multiBandInfoData = {
+      band_descriptions: [
+        [1, 'Band 1'],
+        [2, 'Band 2'],
+        [3, 'Band 3'],
+        [4, 'Band 4'],
+      ],
+    };
+
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => multiBandInfoData,
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockTileJsonData,
+      } as Response);
+
+    const { result } = renderHook(() => useCOGViewer(), { wrapper });
+
+    await act(async () => {
+      await result.current.fetchMetadata(mockCogUrl);
+    });
+
+    await waitFor(() => {
+      expect(result.current.selectedBands).toEqual([1, 2, 3]);
+    });
+
+    const tileUrlFetchCall = vi.mocked(fetch).mock.calls[1][0] as string;
+    expect(tileUrlFetchCall).toContain('&bidx=1&bidx=2&bidx=3');
+    expect(tileUrlFetchCall).not.toContain('&bidx=4');
+  });
+
+  it('should default to single band when metadata has one band', async () => {
+    const singleBandInfoData = {
+      band_descriptions: [[1, 'Band 1']],
+    };
+
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => singleBandInfoData,
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockTileJsonData,
+      } as Response);
+
+    const { result } = renderHook(() => useCOGViewer(), { wrapper });
+
+    await act(async () => {
+      await result.current.fetchMetadata(mockCogUrl);
+    });
+
+    await waitFor(() => {
+      expect(result.current.selectedBands).toEqual([1]);
+    });
+  });
+
+  it('should default to single band when metadata has no band descriptions', async () => {
+    const noBandInfoData = {};
+
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => noBandInfoData,
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockTileJsonData,
+      } as Response);
+
+    const { result } = renderHook(() => useCOGViewer(), { wrapper });
+
+    await act(async () => {
+      await result.current.fetchMetadata(mockCogUrl);
+    });
+
+    await waitFor(() => {
+      expect(result.current.selectedBands).toEqual([1]);
+    });
   });
 
   it('should handle errors when fetching metadata fails', async () => {

--- a/__tests__/playwright/COGViewerDrawer.test.tsx
+++ b/__tests__/playwright/COGViewerDrawer.test.tsx
@@ -205,7 +205,7 @@ test.describe('COG Viewer Drawer', () => {
       ).toHaveText(
         JSON.stringify(
           {
-            bidx: [1],
+            bidx: [1, 2, 3],
             rescale: [],
             assets: ['cog_default'],
           },
@@ -265,7 +265,7 @@ test.describe('COG Viewer Drawer', () => {
       ).toHaveText(
         JSON.stringify(
           {
-            bidx: [1],
+            bidx: [1, 2, 3],
             rescale: [],
             assets: ['cog_default'],
           },

--- a/__tests__/playwright/COGViewerPage.test.tsx
+++ b/__tests__/playwright/COGViewerPage.test.tsx
@@ -80,7 +80,7 @@ test.describe('COG Viewer Page', () => {
     ).toHaveText(
       JSON.stringify(
         {
-          bidx: [1],
+          bidx: [1, 2, 3],
           rescale: [],
           assets: ['cog_default'],
         },

--- a/hooks/useCOGViewer.ts
+++ b/hooks/useCOGViewer.ts
@@ -24,6 +24,16 @@ type TileJsonResponse = {
   bounds?: [number, number, number, number];
 };
 
+const getDefaultBands = (metadata: COGMetadata): number[] => {
+  const totalBands = metadata.band_descriptions?.length ?? 0;
+
+  if (totalBands <= 1) {
+    return [1];
+  }
+
+  return Array.from({ length: Math.min(totalBands, 3) }, (_, i) => i + 1);
+};
+
 export const useCOGViewer = () => {
   const { message } = App.useApp();
   const [cogUrl, setCogUrl] = useState<string | null>(null);
@@ -154,8 +164,11 @@ export const useCOGViewer = () => {
 
         setMetadata(mergedMetadata);
 
-        // Keep default behavior to a single selected band unless renders specifies bidx.
-        setSelectedBands(parsedRenders.bidx?.slice(0, 3) || [1]);
+        const defaultBands = getDefaultBands(COGdata);
+        const initialBands = parsedRenders.bidx?.slice(0, 3) || defaultBands;
+
+        // Default to metadata-derived bands unless renders specifies bidx.
+        setSelectedBands(initialBands);
         setRescale(parsedRenders.rescale || [[null, null]]);
         setSelectedColormap(parsedRenders.colormap_name || 'Internal');
         setColorFormula(parsedRenders.color_formula || null);
@@ -164,7 +177,7 @@ export const useCOGViewer = () => {
 
         fetchTileUrl(
           url,
-          parsedRenders.bidx || [1],
+          initialBands,
           parsedRenders.rescale || [[null, null]],
           parsedRenders.colormap_name || 'Internal',
           parsedRenders.color_formula || null,


### PR DESCRIPTION
closes #248 

In the `/create-dataset` flow, opening `Generate Renders Object` for a multi-band sample file visually showed 3 bands for the RGB defaults (b1, b2, b3), but accepting options wrote only `bidx: [1]` because the underlying selectedBands state was initialized to a single band and the form’s displayed defaults were not being persisted to state unless the user manually changed all three selectors. 

## Solution
Aligned default state initialization with metadata bands so multi-band inputs now default to the first three bands, single-band inputs default to [1], and missing band metadata also falls back to [1], then ensured the same initialized bands are used for both tile requests and accepted render JSON.