### PR TITLE
Bug/update disasters schema

### DIFF
--- a/FormSchemas/datasets/datasetSchema.json
+++ b/FormSchemas/datasets/datasetSchema.json
@@ -236,9 +236,16 @@
       "type": "object",
       "properties": {
         "dashboard": {
-          "type": "string",
+          "type": ["string", "object"],
           "title": "Dashboard"
         }
+      },
+      "default": {
+        "dashboard": {}
+      },
+      "additionalProperties": {
+        "type": ["string", "object"],
+        "title": "Render"
       }
     },
     "providers": {

--- a/FormSchemas/datasets/uischema.json
+++ b/FormSchemas/datasets/uischema.json
@@ -183,6 +183,12 @@
         "rows": 12
       }
     },
+    "additionalProperties": {
+      "ui:widget": "renders.dashboard",
+      "ui:options": {
+        "rows": 12
+      }
+    },
     "ui:classNames": "renders"
   },
   "temporal_extent": {

--- a/FormSchemas/datasets/uischema.json
+++ b/FormSchemas/datasets/uischema.json
@@ -108,6 +108,7 @@
     }
   },
   "item_assets": {
+    "ui:field": "asset",
     "cog_default": {
       "ui:grid": [
         {

--- a/FormSchemas/disasters/datasetSchema.json
+++ b/FormSchemas/disasters/datasetSchema.json
@@ -257,41 +257,6 @@
     "item_assets": {
       "type": "object",
       "title": "Item Assets",
-      "properties": {
-        "ColorIR": {
-          "type": "object",
-          "title": "ColorIR",
-          "properties": {
-            "type": {
-              "type": "string",
-              "title": "Type"
-            },
-            "roles": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "title": "Roles"
-            },
-            "title": {
-              "type": "string",
-              "title": "Title"
-            },
-            "description": {
-              "type": "string",
-              "title": "Description"
-            }
-          }
-        }
-      },
-      "default": {
-        "ColorIR": {
-          "description": "False color infrared composite combining near-infrared, red, and green bands for vegetation and land cover analysis.",
-          "roles": ["data", "layer"],
-          "title": "Color Infrared",
-          "type": "image/tiff; application=geotiff; profile=cloud-optimized"
-        }
-      },
       "additionalProperties": {
         "type": "object",
         "properties": {

--- a/FormSchemas/disasters/datasetSchema.json
+++ b/FormSchemas/disasters/datasetSchema.json
@@ -289,11 +289,14 @@
         "dashboard": {
           "type": ["string", "object"],
           "title": "Dashboard"
-        },
-        "ColorIR": {
-          "type": ["string", "object"],
-          "title": "ColorIR"
         }
+      },
+      "default": {
+        "dashboard": {}
+      },
+      "additionalProperties": {
+        "type": ["string", "object"],
+        "title": "Render"
       }
     },
     "providers": {

--- a/FormSchemas/disasters/uischema.json
+++ b/FormSchemas/disasters/uischema.json
@@ -185,7 +185,13 @@
         "rows": 12
       }
     },
-    "ColorIR": {
+    "additionalProperties": {
+      "ui:widget": "renders.dashboard",
+      "ui:options": {
+        "rows": 12
+      }
+    },
+    "ui:additionalProperties": {
       "ui:widget": "renders.dashboard",
       "ui:options": {
         "rows": 12

--- a/FormSchemas/disasters/uischema.json
+++ b/FormSchemas/disasters/uischema.json
@@ -137,24 +137,7 @@
     }
   },
   "item_assets": {
-    "ColorIR": {
-      "ui:grid": [
-        {
-          "title": 12,
-          "type": 12
-        },
-        {
-          "description": 12,
-          "roles": 12
-        }
-      ],
-      "description": {
-        "ui:widget": "textarea",
-        "ui:options": {
-          "rows": 4
-        }
-      }
-    },
+    "ui:field": "asset",
     "ui:additionalProperties": {
       "ui:grid": [
         {

--- a/__tests__/utils/AssetsField.test.tsx
+++ b/__tests__/utils/AssetsField.test.tsx
@@ -86,6 +86,31 @@ describe('AssetsField', () => {
     expect(MockSchemaField).toHaveBeenCalledTimes(2);
   });
 
+  it('uses ui:additionalProperties config for dynamic asset keys', () => {
+    const dynamicUiSchema = {
+      'ui:additionalProperties': {
+        'ui:grid': [{ title: 12, type: 12 }],
+        description: {
+          'ui:widget': 'textarea',
+        },
+      },
+    };
+
+    render(<AssetsField {...baseProps} uiSchema={dynamicUiSchema} />);
+
+    const firstSchemaFieldProps = MockSchemaField.mock.calls[0][0];
+    const schemaFieldUiSchema =
+      (firstSchemaFieldProps.uiSchema as Record<string, unknown>) || {};
+
+    expect(schemaFieldUiSchema['ui:grid']).toEqual([{ title: 12, type: 12 }]);
+    expect(schemaFieldUiSchema.description).toEqual({
+      'ui:widget': 'textarea',
+    });
+    expect(schemaFieldUiSchema['ui:options']).toEqual({
+      label: false,
+    });
+  });
+
   it('should add a new asset when the add button is clicked', () => {
     render(<AssetsField {...baseProps} />);
 
@@ -97,7 +122,7 @@ describe('AssetsField', () => {
     const updatedFormData = mockOnChange.mock.calls[0][0];
 
     expect(Object.keys(updatedFormData).length).toBe(3);
-    expect(updatedFormData).toHaveProperty('new_asset');
+    expect(updatedFormData).toHaveProperty('asset_1');
   });
 
   it('should remove an asset', () => {
@@ -178,7 +203,7 @@ describe('AssetsField', () => {
     expect(mockOnChange).toHaveBeenCalledTimes(1);
     const firstUpdate = mockOnChange.mock.calls[0][0];
     expect(Object.keys(firstUpdate).length).toBe(3);
-    expect(firstUpdate).toHaveProperty('new_asset');
+    expect(firstUpdate).toHaveProperty('asset_1');
 
     // --- Second Add ---
     // Rerender the component with the updated form data
@@ -191,7 +216,7 @@ describe('AssetsField', () => {
     expect(mockOnChange).toHaveBeenCalledTimes(2);
     const secondUpdate = mockOnChange.mock.calls[1][0];
     expect(Object.keys(secondUpdate).length).toBe(4);
-    // Check for the next unique key, which should be 'new_asset_1'
-    expect(secondUpdate).toHaveProperty('new_asset_1');
+    // Check for the next unique key, which should be 'asset_2'
+    expect(secondUpdate).toHaveProperty('asset_2');
   });
 });

--- a/app/globals.css
+++ b/app/globals.css
@@ -131,6 +131,16 @@ label[title='cog_default'],
   margin-bottom: 24px !important;
 }
 
+#root_renders .form-additional:first-of-type {
+  flex: 0 0 180px !important;
+  max-width: 280px;
+}
+
+#root_renders .form-additional:nth-of-type(2) {
+  flex: 1 1 auto !important;
+  min-width: 0;
+}
+
 .tenants-field .ant-form-item-label > label {
   font-weight: 600;
   font-size: 1.1em;

--- a/components/ingestion/DatasetIngestionForm.tsx
+++ b/components/ingestion/DatasetIngestionForm.tsx
@@ -21,6 +21,7 @@ import { customValidate } from '@/utils/CustomValidation';
 import { JSONEditorValue } from '@/components/ui/JSONEditor';
 import AdditionalPropertyCard from '@/components/rjsf-components/AdditionalPropertyCard';
 import CodeEditorWidget from '@/components/ui/CodeEditorWidget';
+import AssetField from '@/components/rjsf-components/AssetsField';
 
 import datasetSchema from '@/FormSchemas/datasets/datasetSchema.json';
 import datasetUiSchema from '@/FormSchemas/datasets/uischema.json';
@@ -108,6 +109,10 @@ const lockedFormFields = {
   collection: {
     'ui:readonly': true,
   },
+};
+
+const customFields = {
+  asset: AssetField,
 };
 
 interface FormProps {
@@ -311,6 +316,7 @@ function DatasetIngestionForm({
                 templates={{
                   ObjectFieldTemplate: ObjectFieldTemplate,
                 }}
+                fields={customFields}
                 formData={formScopedData}
                 onChange={onFormDataChanged}
                 onSubmit={handleFormSubmit}

--- a/components/ingestion/rjsfTheme.tsx
+++ b/components/ingestion/rjsfTheme.tsx
@@ -45,7 +45,18 @@ function IconButton<
   S extends RJSFSchema = RJSFSchema,
   F extends GenericObjectType = GenericObjectType,
 >(props: IconButtonProps<T, S, F>) {
-  const { iconType = 'default', icon, onClick, ...otherProps } = props;
+  const {
+    iconType = 'default',
+    icon,
+    onClick,
+    uiSchema,
+    registry,
+    // Keep RJSF-only props from leaking into DOM via AntD Button internals.
+    ...otherProps
+  } = props;
+
+  void uiSchema;
+  void registry;
 
   return (
     <Button

--- a/components/rjsf-components/AssetsField.tsx
+++ b/components/rjsf-components/AssetsField.tsx
@@ -31,11 +31,11 @@ const AssetsField: React.FC<FieldProps> = (props) => {
   }, [formData]);
 
   const generateUniqueKey = useCallback(() => {
-    const newKeyBase = 'new_asset';
     let counter = 1;
-    let newKey = newKeyBase;
+    let newKey = `asset_${counter}`;
     while (formData && formData.hasOwnProperty(newKey)) {
-      newKey = `${newKeyBase}_${counter++}`;
+      counter += 1;
+      newKey = `asset_${counter}`;
     }
     return newKey;
   }, [formData]);
@@ -129,6 +129,21 @@ const AssetsField: React.FC<FieldProps> = (props) => {
           path: [...fieldPathId.path, key],
         };
         const assetFormData = formData?.[key] ?? {};
+        const rawAssetUiSchema = (uiSchema?.[key] ||
+          uiSchema?.['ui:additionalProperties'] ||
+          {}) as Record<string, unknown>;
+        const nestedUiOptions =
+          typeof rawAssetUiSchema['ui:options'] === 'object'
+            ? (rawAssetUiSchema['ui:options'] as Record<string, unknown>)
+            : {};
+        const assetUiSchema = {
+          ...rawAssetUiSchema,
+          'ui:title': '',
+          'ui:options': {
+            ...nestedUiOptions,
+            label: false,
+          },
+        };
 
         return (
           <Card key={key} size="small" style={{ marginBottom: '16px' }}>
@@ -144,7 +159,7 @@ const AssetsField: React.FC<FieldProps> = (props) => {
               <SchemaField
                 {...props}
                 schema={assetDetailsSchema}
-                uiSchema={uiSchema?.[key] || {}}
+                uiSchema={assetUiSchema}
                 fieldPathId={assetIdSchema}
                 formData={assetFormData}
                 onChange={(newAssetValue, childPath) => {

--- a/components/rjsf-components/ObjectFieldTemplate.tsx
+++ b/components/rjsf-components/ObjectFieldTemplate.tsx
@@ -28,7 +28,7 @@ import { CloudUploadOutlined, ImportOutlined } from '@ant-design/icons';
 
 import COGDrawerViewer from '@/components/COGViewer/COGDrawerViewer';
 import ThumbnailUploaderDrawer from '@/components/thumbnails/ThumbnailUploaderDrawer';
-import { Alert } from 'antd';
+import { Alert, Divider, Typography } from 'antd';
 import DiscoveryItemObjectFieldTemplate from './DiscoveryItemObjectFieldTemplate'; // Import the specific template
 
 const DESCRIPTION_COL_STYLE = {
@@ -296,33 +296,49 @@ export default function ObjectFieldTemplate<
                         return (
                           <Col key={element.name} span={24}>
                             {isDashboardField(element) ? (
-                              <div
-                                style={{
-                                  display: 'flex',
-                                  alignItems: 'stretch',
-                                  flexDirection: 'column',
-                                }}
-                              >
-                                {element.content}
-                                {errorMessage && (
-                                  <div key={errorMessage}>
-                                    {' '}
-                                    <Alert
-                                      message={errorMessage}
-                                      type="error"
-                                      showIcon
-                                      style={{ marginBottom: '10px' }}
-                                    />
-                                  </div>
-                                )}
-                                <Button
-                                  type="primary"
-                                  onClick={handleOpenCOGDrawer}
-                                  icon={<ImportOutlined />}
+                              <>
+                                <div
+                                  style={{
+                                    display: 'flex',
+                                    alignItems: 'stretch',
+                                    flexDirection: 'column',
+                                  }}
                                 >
-                                  Generate Renders Object From Sample File
-                                </Button>
-                              </div>
+                                  {element.content}
+                                  {errorMessage && (
+                                    <div key={errorMessage}>
+                                      {' '}
+                                      <Alert
+                                        message={errorMessage}
+                                        type="error"
+                                        showIcon
+                                        style={{ marginBottom: '10px' }}
+                                      />
+                                    </div>
+                                  )}
+                                  <Button
+                                    type="primary"
+                                    onClick={handleOpenCOGDrawer}
+                                    icon={<ImportOutlined />}
+                                    style={{
+                                      alignSelf: 'flex-end',
+                                      marginBottom: '16px',
+                                    }}
+                                  >
+                                    Generate Renders Object From Sample File
+                                  </Button>
+                                  <Divider style={{ margin: '0 0 16px 0' }} />
+                                </div>
+                                <Typography.Text
+                                  type="secondary"
+                                  style={{
+                                    display: 'block',
+                                    marginBottom: '8px',
+                                  }}
+                                >
+                                  Optional Additional Renders Objects
+                                </Typography.Text>
+                              </>
                             ) : (
                               element.content
                             )}


### PR DESCRIPTION
to close #250 

This makes 

1. `renders` always have a `dashboard` object, but optionally accept additional objects:
    
```json
  "renders": {
    "dashboard": {
      "assets": [
        "ColorIR"
      ],
      "bidx": [
        1,
        2,
        3
      ],
      "nodata": 0
    },
    "ColorIR": {
      "assets": [
        "ColorIR"
      ],
      "bidx": [
        1,
        2,
        3
      ],
      "nodata": 0
    }
  }
```
Before pasting JSON:
<img width="80%"  alt="Screenshot 2026-04-28 at 11 21 24 AM" src="https://github.com/user-attachments/assets/50554cc3-d61e-4606-8201-0b4353e09d7a" />
After pasting JSON
<img width="80%" alt="Screenshot 2026-04-28 at 11 22 40 AM" src="https://github.com/user-attachments/assets/7392e5e2-417a-49d9-bf00-42b104b915c4" />


2.  the `item_assets` will now allow 0 or more objects that the user can name.  previously, it was `item_assets.cog_default` for default schemas. 
on form load:
<img width="80%"  alt="Screenshot 2026-04-28 at 11 21 35 AM" src="https://github.com/user-attachments/assets/1a622a85-fc45-42e3-becd-d9a552d0be99" />

click to add item_asset:
<img width="80%" alt="Screenshot 2026-04-28 at 11 21 47 AM" src="https://github.com/user-attachments/assets/5c9f1287-5b13-489d-a2fa-efbf40541bf2" />

after pasting JSON:
<img width="80%" alt="Screenshot 2026-04-28 at 11 23 25 AM" src="https://github.com/user-attachments/assets/99b61185-cc1a-41bc-ad1a-5e0ede75f6e2" />
