### PR TITLE
fix: pin uuid resolution to 14.0.0 for security advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
   },
   "resolutions": {
     "fast-xml-parser": "5.7.0",
+    "uuid": "14.0.0",
     "eslint/minimatch": "3.1.4",
     "@eslint/eslintrc/minimatch": "3.1.4",
     "@humanwhocodes/config-array/minimatch": "3.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11663,12 +11663,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^11.0.0":
-  version: 11.1.0
-  resolution: "uuid@npm:11.1.0"
+"uuid@npm:14.0.0":
+  version: 14.0.0
+  resolution: "uuid@npm:14.0.0"
   bin:
-    uuid: dist/esm/bin/uuid
-  checksum: 10c0/34aa51b9874ae398c2b799c88a127701408cd581ee89ec3baa53509dd8728cbb25826f2a038f9465f8b7be446f0fbf11558862965b18d21c993684297628d4d3
+    uuid: dist-node/bin/uuid
+  checksum: 10c0/a57ae7794c45005c1a9208989196c5baf79a7679c30f43c1bee9033a2c4d113a2cea216fa6fcc9663b08b0d55635df1a7c6eb7e7f3d21c3e50688c698fa39a50
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
This PR mitigates Dependabot advisory #111 for uuid by pinning the transitive uuid version to 14.0.0 at the workspace level.

## Why
Dependabot cannot auto-resolve this issue because the current stable Amplify dependency chain still pulls uuid via older constraints.
To unblock security remediation now, this PR applies a Yarn resolution override for uuid.

## Changes
- Added a workspace resolution for uuid = 14.0.0 in [package.json]
- Regenerated [yarn.lock] to enforce the updated transitive version

## Validation
- Ran install with mutable lockfile update enabled
- Confirmed effective resolution with:
- CI=1 yarn why uuid
- Result shows Amplify paths resolving to uuid 14.0.0