### PR TITLE
create rjsf docs

### DIFF
--- a/FormSchemas/datasets/datasetSchema.json
+++ b/FormSchemas/datasets/datasetSchema.json
@@ -1,5 +1,34 @@
 {
   "type": "object",
+  "default": {
+    "license": "CC0-1.0",
+    "stac_version": "1.0.0",
+    "spatial_extent": {
+      "xmin": -180,
+      "ymin": -90,
+      "xmax": 180,
+      "ymax": 90
+    },
+    "stac_extensions": [
+      "https://stac-extensions.github.io/render/v1.0.0/schema.json",
+      "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+    ],
+    "providers": [
+      {
+        "name": "NASA VEDA",
+        "roles": ["host"],
+        "url": "https://www.earthdata.nasa.gov/dashboard/"
+      }
+    ],
+    "item_assets": {
+      "cog_default": {
+        "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+        "roles": ["data", "layer"],
+        "title": "Default COG Layer",
+        "description": "Cloud optimized default layer to display on map"
+      }
+    }
+  },
   "required": [
     "collection",
     "title",
@@ -208,25 +237,27 @@
     "item_assets": {
       "type": "object",
       "title": "Item Assets",
-      "properties": {
-        "cog_default": {
-          "type": "object",
-          "properties": {
-            "type": {
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "title": "Type"
+          },
+          "roles": {
+            "type": "array",
+            "items": {
               "type": "string"
             },
-            "roles": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "title": {
-              "type": "string"
-            },
-            "description": {
-              "type": "string"
-            }
+            "title": "Roles"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
           }
         }
       }

--- a/FormSchemas/datasets/uischema.json
+++ b/FormSchemas/datasets/uischema.json
@@ -109,7 +109,7 @@
   },
   "item_assets": {
     "ui:field": "asset",
-    "cog_default": {
+    "ui:additionalProperties": {
       "ui:grid": [
         {
           "title": 12,
@@ -123,7 +123,7 @@
       "description": {
         "ui:widget": "textarea",
         "ui:options": {
-          "rows": 8
+          "rows": 4
         }
       }
     }

--- a/FormSchemas/disasters/datasetSchema.json
+++ b/FormSchemas/disasters/datasetSchema.json
@@ -1,5 +1,27 @@
 {
   "type": "object",
+  "default": {
+    "license": "CC0-1.0",
+    "stac_version": "1.0.0",
+    "spatial_extent": {
+      "xmin": -180,
+      "ymin": -90,
+      "xmax": 180,
+      "ymax": 90
+    },
+    "stac_extensions": [
+      "https://stac-extensions.github.io/render/v1.0.0/schema.json",
+      "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+    ],
+    "providers": [
+      {
+        "name": "NASA VEDA",
+        "roles": ["host"],
+        "url": "https://www.earthdata.nasa.gov/dashboard/"
+      }
+    ],
+    "item_assets": {}
+  },
   "required": [
     "collection",
     "title",

--- a/README.md
+++ b/README.md
@@ -62,6 +62,23 @@ https://nasa-impact.github.io/veda-ingest-ui/
 └── __tests__/            # Test suites (unit, integration, e2e)
 ```
 
+## Form System & RJSF Customization
+
+This application uses [react-jsonschema-form (RJSF)](https://rjsf-team.github.io/react-jsonschema-form/) to generate forms from JSON Schema definitions. This approach provides several key advantages:
+
+- **Schema-driven**: Form structure, validation rules, and defaults are defined once in JSON Schema and reused across create/edit flows, reducing code duplication
+- **Multi-profile support**: Different data ingestion profiles (e.g., `default` vs. `disasters`) can have distinct forms with different field requirements, without duplicating form logic
+- **Dual interface**: Users can edit via visual form **or** direct JSON editor, with bidirectional sync and validation
+- **Composability**: Forms initialize from defaults, validate against schema, and serialize back to schema-compliant JSON
+
+**Why customization is necessary?**
+
+- **Layout control**: RJSF out-of-the-box doesn't support complex responsive grid layouts; we customize ObjectFieldTemplate with Ant Design's grid system for professional multi-column layouts
+- **Domain-specific widgets**: Standard input widgets don't handle some VEDA-specific fields and complex objects (COG file validation, renders dashboard, asset management, regex fields). Custom widgets encapsulate this domain logic
+- **Theme integration**: Ant Design theming requires custom overrides to work reliably with RJSF v6
+
+See [RJSF Customization Guide](docs/rjsf-customization.md) for detailed patterns and component architecture.
+
 # Architecture
 
 The application supports two primary workflows:
@@ -422,6 +439,8 @@ const cleanedData = sanitizeFormData(formData);
 ## Configuring the Validation Form
 
 The fields in the Validation Form are configured by a combination of the json schema in the [jsonschema.json file](FormSchemas/**/jsonschema.json) and the UI Schema in the [uischema.json file](FormSchemas/**/uischema.json). To modify fields in the form, a developer must update the json schema to include the proper JSON schema data fields and then modify the ui Schema to have any new or renamed fields in the desired location.
+
+For customization details (templates, widgets, fields, and theme overrides), see [RJSF Customization Guide](docs/rjsf-customization.md).
 
 The Form uses a 24 column grid format and the layout of each row is dictated by the "ui:grid" array in that json. Each row is defined as an object with each field allowed up to 24 columns wide. For example:
 

--- a/__tests__/components/DatasetIngestionForm.test.tsx
+++ b/__tests__/components/DatasetIngestionForm.test.tsx
@@ -102,6 +102,16 @@ vi.mock('@/utils/ObjectFieldTemplate', () => ({
 vi.mock('@/FormSchemas/datasets/datasetSchema.json', () => ({
   default: {
     type: 'object',
+    default: {
+      item_assets: {
+        cog_default: {
+          type: 'image/tiff; application=geotiff; profile=cloud-optimized',
+          roles: ['data', 'layer'],
+          title: 'Default COG Layer',
+          description: 'Cloud optimized default layer to display on map',
+        },
+      },
+    },
     properties: {
       collection: { type: 'string' },
       tenants: {
@@ -119,6 +129,16 @@ vi.mock('@/FormSchemas/datasets/uischema.json', () => ({
 vi.mock('@/FormSchemas/disasters/datasetSchema.json', () => ({
   default: {
     type: 'object',
+    default: {
+      item_assets: {
+        cog_default: {
+          type: 'image/tiff; application=geotiff; profile=cloud-optimized',
+          roles: ['data', 'layer'],
+          title: 'Default COG Layer',
+          description: 'Cloud optimized default layer to display on map',
+        },
+      },
+    },
     properties: {
       disaster_only: { type: 'boolean' },
     },
@@ -381,7 +401,7 @@ describe('DatasetIngestionForm', () => {
     expect(uiSchema.collection['ui:readonly']).toBe(true);
   });
 
-  it('does not inject default item_assets for default profile on new forms', async () => {
+  it('initializes default profile item_assets from schema defaults on new forms', async () => {
     mockedEnv.DATASET_FORM_SCHEMA_PROFILE = 'default';
     const mockSetFormData = vi.fn();
 
@@ -400,10 +420,17 @@ describe('DatasetIngestionForm', () => {
     const updaterFn = mockSetFormData.mock.calls[0][0];
     const newState = updaterFn({});
 
-    expect(newState.item_assets).toBeUndefined();
+    expect(newState.item_assets).toEqual({
+      cog_default: {
+        type: 'image/tiff; application=geotiff; profile=cloud-optimized',
+        roles: ['data', 'layer'],
+        title: 'Default COG Layer',
+        description: 'Cloud optimized default layer to display on map',
+      },
+    });
   });
 
-  it('does not inject default item_assets for disasters profile on new forms', async () => {
+  it('initializes disasters profile item_assets from schema defaults on new forms', async () => {
     mockedEnv.DATASET_FORM_SCHEMA_PROFILE = 'disasters';
     const mockSetFormData = vi.fn();
 
@@ -422,7 +449,14 @@ describe('DatasetIngestionForm', () => {
     const updaterFn = mockSetFormData.mock.calls[0][0];
     const newState = updaterFn({});
 
-    expect(newState.item_assets).toBeUndefined();
+    expect(newState.item_assets).toEqual({
+      cog_default: {
+        type: 'image/tiff; application=geotiff; profile=cloud-optimized',
+        roles: ['data', 'layer'],
+        title: 'Default COG Layer',
+        description: 'Cloud optimized default layer to display on map',
+      },
+    });
   });
 
   it('correctly handles nested dashboard objects in form rendering', () => {
@@ -503,12 +537,12 @@ describe('DatasetIngestionForm', () => {
     );
 
     expect(useTenants).toHaveBeenCalledWith(
-      {
+      expect.objectContaining({
         type: 'object',
         properties: {
           disaster_only: { type: 'boolean' },
         },
-      },
+      }),
       {
         disaster_only: { 'ui:widget': 'checkbox' },
       }

--- a/components/ingestion/DatasetIngestionForm.tsx
+++ b/components/ingestion/DatasetIngestionForm.tsx
@@ -5,7 +5,6 @@ import '@ant-design/v5-patch-for-react-19';
 import React, {
   useEffect,
   useState,
-  FC,
   memo,
   useCallback,
   lazy,
@@ -14,14 +13,13 @@ import React, {
 import { Button, Tabs, Spin } from 'antd';
 import validator from '@rjsf/validator-ajv8';
 import { JSONSchema7 } from 'json-schema';
-import { WidgetProps } from '@rjsf/utils';
 
 import ObjectFieldTemplate from '@/components/rjsf-components/ObjectFieldTemplate';
 import { customValidate } from '@/utils/CustomValidation';
 import { JSONEditorValue } from '@/components/ui/JSONEditor';
 import AdditionalPropertyCard from '@/components/rjsf-components/AdditionalPropertyCard';
-import CodeEditorWidget from '@/components/ui/CodeEditorWidget';
 import AssetField from '@/components/rjsf-components/AssetsField';
+import { RendersDashboardWidget } from '@/components/rjsf-components/RendersDashboardWidget';
 
 import datasetSchema from '@/FormSchemas/datasets/datasetSchema.json';
 import datasetUiSchema from '@/FormSchemas/datasets/uischema.json';
@@ -36,40 +34,6 @@ import { Form } from './rjsfTheme';
 
 // Lazy load JSONEditor - only needed when JSON tab is active
 const JSONEditor = lazy(() => import('@/components/ui/JSONEditor'));
-
-// --- Adapter Component ---
-// This component accepts RJSF's props and translates them to what CodeEditorWidget expects.
-const RjsfCodeEditorWidget: FC<WidgetProps> = ({
-  value,
-  onChange,
-  readonly,
-}) => {
-  // Convert object to JSON string for display in editor
-  const stringValue = React.useMemo(() => {
-    if (value === null || value === undefined) {
-      return '';
-    }
-    if (typeof value === 'string') {
-      return value;
-    }
-    // If it's an object, stringify it with proper formatting
-    return JSON.stringify(value, null, 2);
-  }, [value]);
-
-  const handleOnChange = (newValue: string) => {
-    // Always pass the raw string value to the form state.
-    // RJSF will handle validation against the schema.
-    onChange(newValue);
-  };
-
-  return (
-    <CodeEditorWidget
-      value={stringValue}
-      onChange={handleOnChange}
-      readOnly={readonly}
-    />
-  );
-};
 
 interface TemporalExtent {
   startdate?: string;
@@ -151,6 +115,8 @@ function DatasetIngestionForm({
     schemaSources[cfg.DATASET_FORM_SCHEMA_PROFILE] || schemaSources.default;
   const selectedSchema = selectedSource.schema;
   const selectedUiSchema = selectedSource.uiSchema;
+  const schemaDefaults =
+    (selectedSchema.default as Record<string, unknown> | undefined) || {};
 
   const {
     schema: dynamicSchema,
@@ -174,34 +140,18 @@ function DatasetIngestionForm({
 
   const formScopedData = formData;
 
-  // --- Set initial "default" data for new forms ---
   useEffect(() => {
-    if (!isEditMode && (!formData || Object.keys(formData).length === 0)) {
+    if (
+      !isEditMode &&
+      (!formData || Object.keys(formData).length === 0) &&
+      Object.keys(schemaDefaults).length > 0
+    ) {
       setFormData((prevFormData) => ({
+        ...schemaDefaults,
         ...prevFormData,
-        // Manually set "default" values here
-        license: 'CC0-1.0',
-        stac_version: '1.0.0',
-        spatial_extent: {
-          xmin: -180,
-          ymin: -90,
-          xmax: 180,
-          ymax: 90,
-        },
-        stac_extensions: [
-          'https://stac-extensions.github.io/render/v1.0.0/schema.json',
-          'https://stac-extensions.github.io/item-assets/v1.0.0/schema.json',
-        ],
-        providers: [
-          {
-            name: 'NASA VEDA',
-            roles: ['host'],
-            url: 'https://www.earthdata.nasa.gov/dashboard/',
-          },
-        ],
       }));
     }
-  }, [isEditMode, formData, setFormData]);
+  }, [isEditMode, formData, schemaDefaults, setFormData]);
 
   useEffect(() => {
     if (defaultTemporalExtent) {
@@ -276,7 +226,7 @@ function DatasetIngestionForm({
   );
 
   const widgets = {
-    'renders.dashboard': RjsfCodeEditorWidget,
+    'renders.dashboard': RendersDashboardWidget,
     testableUrl: TestableUrlWidget,
     regexString: RegexStringWidget,
   };

--- a/components/rjsf-components/ObjectFieldTemplate.tsx
+++ b/components/rjsf-components/ObjectFieldTemplate.tsx
@@ -8,7 +8,6 @@ import {
   FormContextType,
   GenericObjectType,
   ObjectFieldTemplateProps,
-  ObjectFieldTemplatePropertyType,
   RJSFSchema,
   StrictRJSFSchema,
   canExpand,
@@ -24,11 +23,9 @@ import {
   ConfigConsumerProps,
 } from 'antd/lib/config-provider/context';
 import Button from 'antd/lib/button';
-import { CloudUploadOutlined, ImportOutlined } from '@ant-design/icons';
+import { CloudUploadOutlined } from '@ant-design/icons';
 
-import COGDrawerViewer from '@/components/COGViewer/COGDrawerViewer';
 import ThumbnailUploaderDrawer from '@/components/thumbnails/ThumbnailUploaderDrawer';
-import { Alert, Divider, Typography } from 'antd';
 import DiscoveryItemObjectFieldTemplate from './DiscoveryItemObjectFieldTemplate'; // Import the specific template
 
 const DESCRIPTION_COL_STYLE = {
@@ -56,11 +53,6 @@ export default function ObjectFieldTemplate<
   } = props;
   const formContext = registry.formContext;
 
-  const [errorMessage, setErrorMessage] = useState('');
-  const [cogDrawerOpen, setCOGDrawerOpen] = useState(false);
-  const [drawerUrl, setDrawerUrl] = useState<string | null>(null);
-  const [renders, setRenders] = useState<string | null>(null);
-  const [, forceUpdate] = useState(0);
   const [thumbnailDrawerOpen, setThumbnailDrawerOpen] = useState(false);
 
   const uiOptions = getUiOptions<T, S, F>(uiSchema);
@@ -84,10 +76,6 @@ export default function ObjectFieldTemplate<
     formContext as GenericObjectType;
 
   type FormDataLike = {
-    sample_files?: string[];
-    renders?: {
-      dashboard?: string;
-    };
     assets?: {
       thumbnail?: Record<string, unknown>;
     };
@@ -105,43 +93,8 @@ export default function ObjectFieldTemplate<
     | FormContextWithUpdate
     | undefined;
 
-  const handleOpenCOGDrawer = () => {
-    if (
-      !formContextWithUpdate ||
-      typeof formContextWithUpdate.updateFormData !== 'function'
-    ) {
-      console.error('formContext or updateFormData is not available.');
-      return;
-    }
-    // Use full form data from formContext
-    const fullFormData = formContextWithUpdate.formData || {};
-    const sampleUrl: string | undefined = fullFormData?.sample_files?.[0]; // Use full form data
-    const rendersDashboardEntry: string | undefined =
-      fullFormData?.renders?.dashboard;
-
-    if (!sampleUrl) {
-      setErrorMessage('Sample File URL is required');
-      forceUpdate((prev) => prev + 1);
-      return;
-    }
-
-    setErrorMessage('');
-    setDrawerUrl(sampleUrl);
-    setCOGDrawerOpen(true);
-
-    if (rendersDashboardEntry) {
-      setRenders(rendersDashboardEntry);
-    }
-    forceUpdate((prev) => prev + 1);
-  };
-
   const handleOpenUploadDrawer = () => {
     setThumbnailDrawerOpen(true);
-    forceUpdate((prev) => prev + 1);
-  };
-
-  const handleCloseCOGDrawer = () => {
-    setCOGDrawerOpen(false);
   };
 
   const handleUploadSuccess = (s3Uri: string) => {
@@ -169,35 +122,6 @@ export default function ObjectFieldTemplate<
     });
     setThumbnailDrawerOpen(false);
   };
-
-  const handleAcceptRenderOptions = (renderOptions: string) => {
-    if (
-      !formContextWithUpdate ||
-      typeof formContextWithUpdate.updateFormData !== 'function'
-    ) {
-      console.error('formContext or updateFormData is not available.');
-      return;
-    }
-
-    formContextWithUpdate.updateFormData((prevData: FormDataLike) => {
-      const updatedFormData = {
-        ...prevData,
-        renders: {
-          ...prevData.renders,
-          dashboard: renderOptions, // only update renderOptions without overwriting other fields
-        },
-      };
-
-      return updatedFormData;
-    });
-  };
-
-  const isDashboardField = (element: ObjectFieldTemplatePropertyType) =>
-    element.name === 'dashboard' &&
-    (
-      (element.content?.props as { fieldPathId?: { $id?: string } })
-        ?.fieldPathId?.$id || ''
-    ).includes('renders');
   // Apply discovery item template only to the array item object itself,
   // not nested objects like discovery_items[].assets.
   const isDiscoveryItem =
@@ -292,56 +216,10 @@ export default function ObjectFieldTemplate<
                     )
                   : properties
                       .filter((e) => !e.hidden)
-                      .map((element: ObjectFieldTemplatePropertyType) => {
+                      .map((element) => {
                         return (
                           <Col key={element.name} span={24}>
-                            {isDashboardField(element) ? (
-                              <>
-                                <div
-                                  style={{
-                                    display: 'flex',
-                                    alignItems: 'stretch',
-                                    flexDirection: 'column',
-                                  }}
-                                >
-                                  {element.content}
-                                  {errorMessage && (
-                                    <div key={errorMessage}>
-                                      {' '}
-                                      <Alert
-                                        message={errorMessage}
-                                        type="error"
-                                        showIcon
-                                        style={{ marginBottom: '10px' }}
-                                      />
-                                    </div>
-                                  )}
-                                  <Button
-                                    type="primary"
-                                    onClick={handleOpenCOGDrawer}
-                                    icon={<ImportOutlined />}
-                                    style={{
-                                      alignSelf: 'flex-end',
-                                      marginBottom: '16px',
-                                    }}
-                                  >
-                                    Generate Renders Object From Sample File
-                                  </Button>
-                                  <Divider style={{ margin: '0 0 16px 0' }} />
-                                </div>
-                                <Typography.Text
-                                  type="secondary"
-                                  style={{
-                                    display: 'block',
-                                    marginBottom: '8px',
-                                  }}
-                                >
-                                  Optional Additional Renders Objects
-                                </Typography.Text>
-                              </>
-                            ) : (
-                              element.content
-                            )}
+                            {element.content}
                           </Col>
                         );
                       })}
@@ -363,13 +241,6 @@ export default function ObjectFieldTemplate<
                 </Col>
               )}
             </fieldset>
-            <COGDrawerViewer
-              drawerOpen={cogDrawerOpen}
-              url={drawerUrl || ''}
-              renders={renders}
-              onClose={handleCloseCOGDrawer}
-              onAcceptRenderOptions={handleAcceptRenderOptions}
-            />
             <ThumbnailUploaderDrawer
               open={thumbnailDrawerOpen}
               onClose={() => setThumbnailDrawerOpen(false)}

--- a/components/rjsf-components/RendersDashboardWidget.tsx
+++ b/components/rjsf-components/RendersDashboardWidget.tsx
@@ -1,0 +1,116 @@
+import { WidgetProps } from '@rjsf/utils';
+import { Alert, Button, Divider, Typography } from 'antd';
+import { ImportOutlined } from '@ant-design/icons';
+import { useMemo, useState } from 'react';
+
+import COGDrawerViewer from '@/components/COGViewer/COGDrawerViewer';
+import CodeEditorWidget from '@/components/ui/CodeEditorWidget';
+
+type FormContextWithSampleFiles = {
+  formData?: {
+    sample_files?: string[];
+    renders?: {
+      dashboard?: string;
+    };
+  };
+};
+
+const toEditorString = (value: unknown): string => {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  return JSON.stringify(value, null, 2);
+};
+
+export const RendersDashboardWidget = ({
+  id,
+  value,
+  onChange,
+  disabled,
+  readonly,
+  registry,
+  formContext,
+}: WidgetProps) => {
+  const [errorMessage, setErrorMessage] = useState('');
+  const [cogDrawerOpen, setCOGDrawerOpen] = useState(false);
+  const [drawerUrl, setDrawerUrl] = useState<string | null>(null);
+
+  const editorValue = useMemo(() => toEditorString(value), [value]);
+  // In RJSF v6, widgets should prefer registry.formContext; keep prop fallback.
+  const context = (registry?.formContext || formContext) as
+    | FormContextWithSampleFiles
+    | undefined;
+  const isDashboardField = id.endsWith('_dashboard');
+
+  const handleOpenCOGDrawer = () => {
+    const sampleUrl = context?.formData?.sample_files?.[0];
+    if (!sampleUrl) {
+      setErrorMessage('Sample File URL is required');
+      return;
+    }
+
+    setErrorMessage('');
+    setDrawerUrl(sampleUrl);
+    setCOGDrawerOpen(true);
+  };
+
+  const handleAcceptRenderOptions = (renderOptions: string) => {
+    onChange(renderOptions);
+  };
+
+  const handleEditorChange = (newValue: string) => {
+    setErrorMessage('');
+    onChange(newValue);
+  };
+
+  return (
+    <>
+      <CodeEditorWidget
+        id={id}
+        value={editorValue}
+        onChange={handleEditorChange}
+        readOnly={!!(readonly || disabled)}
+      />
+
+      {isDashboardField && (
+        <>
+          {errorMessage && (
+            <Alert
+              message={errorMessage}
+              type="error"
+              showIcon
+              style={{ marginTop: '10px', marginBottom: '10px' }}
+            />
+          )}
+          <Button
+            type="primary"
+            onClick={handleOpenCOGDrawer}
+            icon={<ImportOutlined />}
+            style={{ marginTop: '10px', marginBottom: '16px' }}
+            disabled={readonly || disabled}
+          >
+            Generate Renders Object From Sample File
+          </Button>
+          <Divider style={{ margin: '0 0 16px 0' }} />
+          <Typography.Text
+            type="secondary"
+            style={{ display: 'block', marginBottom: '8px' }}
+          >
+            Optional Additional Renders Objects
+          </Typography.Text>
+        </>
+      )}
+
+      <COGDrawerViewer
+        drawerOpen={cogDrawerOpen}
+        url={drawerUrl || ''}
+        renders={typeof value === 'string' ? value : undefined}
+        onClose={() => setCOGDrawerOpen(false)}
+        onAcceptRenderOptions={handleAcceptRenderOptions}
+      />
+    </>
+  );
+};

--- a/docs/rjsf-customization.md
+++ b/docs/rjsf-customization.md
@@ -1,0 +1,76 @@
+# RJSF Customization Guide
+
+This project uses RJSF (react-jsonschema-form) with custom templates, fields, widgets, and a theme override.
+
+Use this document to understand where behavior lives and which customization hook to use when adding new form UX.
+
+## Architecture
+
+RJSF rendering is assembled in the ingestion form components:
+
+- `components/ingestion/DatasetIngestionForm.tsx`
+- `components/ingestion/CollectionIngestionForm.tsx`
+- `components/ingestion/rjsfTheme.tsx`
+
+Schemas and layout metadata live in:
+
+- `FormSchemas/**/datasetSchema.json`
+- `FormSchemas/**/uischema.json`
+
+## Customization Matrix
+
+Use this as the map from uiSchema markers to implementation.
+
+| uiSchema marker                                        | RJSF hook                        | Implementation                                                    | Purpose                                                            |
+| ------------------------------------------------------ | -------------------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------ |
+| `ui:grid`                                              | `ObjectFieldTemplate`            | `components/rjsf-components/ObjectFieldTemplate.tsx`              | 24-column row/column layout for object fields                      |
+| discovery item object (`root_discovery_items_<index>`) | `ObjectFieldTemplate` delegation | `components/rjsf-components/DiscoveryItemObjectFieldTemplate.tsx` | Collapse advanced discovery item rows into "More Options"          |
+| `ui:field: asset`                                      | custom field                     | `components/rjsf-components/AssetsField.tsx`                      | Editable object keys + nested asset schema rendering               |
+| `ui:field: BboxField`                                  | custom field                     | `utils/BboxField.tsx`                                             | Specialized bbox UX                                                |
+| `ui:field: interval`                                   | custom field                     | `utils/IntervalField.tsx`                                         | Specialized interval UX                                            |
+| `ui:widget: testableUrl`                               | custom widget                    | `components/rjsf-components/TestableUrlWidget.tsx`                | URL input with validation call                                     |
+| `ui:widget: regexString`                               | custom widget                    | `components/rjsf-components/RegexStringWidget.tsx`                | Regex input preserving slash escaping                              |
+| `ui:widget: renders.dashboard`                         | custom widget                    | `components/rjsf-components/RendersDashboardWidget.tsx`           | JSON editor for renders + COG-assisted dashboard render generation |
+
+## Theme Override
+
+The RJSF Ant Design theme is wrapped in `components/ingestion/rjsfTheme.tsx`.
+
+Reason:
+
+- `@rjsf/antd` icon import incompatibility with Next.js in current version.
+
+What is overridden:
+
+- `ButtonTemplates`
+- `ErrorListTemplate`
+
+If this compatibility issue is fixed in a future RJSF/AntD version, this file can likely be simplified or removed.
+
+## Choosing The Right Hook
+
+When adding customization, use the smallest hook that solves the problem:
+
+- Use `ui:widget` when behavior is specific to one value/editor.
+- Use `ui:field` when you need to control a compound schema node (object/array) with custom rendering logic.
+- Use template overrides only for cross-cutting layout/presentation concerns.
+
+Rule of thumb: avoid putting domain-specific behavior in `ObjectFieldTemplate` unless it affects all object rendering.
+
+## Adding A New Custom Widget
+
+1. Add a widget component under `components/rjsf-components/`.
+2. Register it in the relevant form component (`DatasetIngestionForm` and/or `CollectionIngestionForm`) via the `widgets` prop.
+3. Reference it in the appropriate uiSchema using `ui:widget`.
+4. Add/update tests for widget behavior and form integration.
+
+## Current Form Context Contract
+
+Dataset form currently passes this `formContext` into RJSF:
+
+- `formData`
+- `updateFormData`
+
+Collection form currently does not pass `formContext`.
+
+If future widgets require cross-field reads/writes in collection flows, align both forms to a shared typed `formContext` contract.


### PR DESCRIPTION
this creates documentation around how to style and customize the forms using RJSF and custom widgets.

- I did a little cleanup to move out of the ObjectFieldTemplate the renders Object handling to make it easier to maintain
- I realized in the previous work to support disasters that the sub-fields for item_asset were not rendering, so that bug is fixed.