### PR TITLE
add structured frontend logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,31 @@ Current API authorization requirements:
 - `GET/PUT /api/existing-collection/[collectionId]`: authenticated + stac edit capability
 - `POST /api/upload-url`: authenticated + create capability
 
+### API and Frontend Logging
+
+Structured logging is shared across server and browser code via [lib/structuredLogger.ts](lib/structuredLogger.ts).
+
+- Server/API route logging:
+  - Use `logStructured` for service/domain events.
+  - Use `createRequestLogContext`, `logRequestStart`, `logRequestEnd`, and `logRequestError` for request lifecycle logs.
+- Frontend logging:
+  - Use `logFrontend` for non-error client events.
+  - Use `logFrontendError` for client-side exceptions and recoverable failures in hooks/components.
+  - Frontend event names are prefixed as `frontend.<event>` to keep API and browser logs cohesive and easy to filter.
+  - Browser logs are forwarded to `POST /api/frontend-logs` by default, where they are re-emitted by the server logger for CloudWatch ingestion.
+  - In production, `POST /api/frontend-logs` applies an origin guard that validates `origin` against `x-forwarded-host`/`host` to support Amplify and branch-preview domains without a static allowlist.
+
+Frontend log forwarding toggle:
+
+- `NEXT_PUBLIC_FORWARD_FRONTEND_LOGS=true|false` (defaults to `true`; automatically disabled in test runtime)
+
+Example frontend event categories in this app include:
+
+- `frontend.error_boundary.*`
+- `frontend.cog.*`
+- `frontend.thumbnail.*`
+- `frontend.ingestion.*`
+
 ### Mocking Auth Locally
 
 For local/test development:

--- a/__tests__/api/FrontendLogsRoute.test.ts
+++ b/__tests__/api/FrontendLogsRoute.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi, beforeEach, type Mock } from 'vitest';
+import { NextRequest } from 'next/server';
+import { POST } from '@/app/api/frontend-logs/route';
+import { auth } from '@/auth';
+
+vi.mock('@/auth', () => ({
+  auth: vi.fn(),
+}));
+
+const authMock = auth as Mock;
+
+const validLogEntry = {
+  level: 'error',
+  event: 'frontend.test.event',
+  details: {
+    runtime: 'browser',
+    pathname: '/collections',
+  },
+  clientTimestamp: '2026-05-14T00:00:00.000Z',
+};
+
+describe('POST /api/frontend-logs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authMock.mockResolvedValue({
+      user: { name: 'Test User' },
+      scopes: ['dataset:create'],
+      tenants: ['Public'],
+    });
+  });
+
+  it('returns 403 when origin host mismatches forwarded host in production', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+
+    const request = new NextRequest(
+      'https://ingest.example.com/api/frontend-logs',
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          origin: 'https://evil.example.com',
+          'x-forwarded-host': 'ingest.example.com',
+        },
+        body: JSON.stringify({ logs: [validLogEntry] }),
+      }
+    );
+
+    const response = await POST(request);
+    const json = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(json).toEqual({ error: 'Origin validation failed' });
+  });
+
+  it('returns 202 for valid same-origin forwarded-host requests in production', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+
+    const request = new NextRequest(
+      'https://ingest.example.com/api/frontend-logs',
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          origin: 'https://preview.example.amplifyapp.com',
+          'x-forwarded-host': 'preview.example.amplifyapp.com',
+          'sec-fetch-site': 'same-origin',
+        },
+        body: JSON.stringify({ logs: [validLogEntry] }),
+      }
+    );
+
+    const response = await POST(request);
+    const json = await response.json();
+
+    expect(response.status).toBe(202);
+    expect(json).toEqual({
+      accepted: true,
+      ingestedCount: 1,
+      droppedCount: 0,
+    });
+  });
+});

--- a/__tests__/hooks/useCOGViewer.test.tsx
+++ b/__tests__/hooks/useCOGViewer.test.tsx
@@ -316,8 +316,9 @@ describe('useCOGViewer', () => {
 
     await waitFor(() => {
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        'Error parsing renders:',
-        expect.any(Error)
+        expect.stringContaining(
+          '"event":"frontend.cog.viewer.parse_renders_failed"'
+        )
       );
     });
 

--- a/__tests__/hooks/useCogValidation.test.ts
+++ b/__tests__/hooks/useCogValidation.test.ts
@@ -154,8 +154,9 @@ describe('useCogValidation', () => {
 
       expect(isValid!).toBe(false);
       expect(consoleSpy).toHaveBeenCalledWith(
-        'COG validation API request failed',
-        expect.any(Error)
+        expect.stringContaining(
+          '"event":"frontend.cog.validation.request_failed"'
+        )
       );
 
       consoleSpy.mockRestore();

--- a/app/(pages)/cog-viewer/_components/CogViewerClient.tsx
+++ b/app/(pages)/cog-viewer/_components/CogViewerClient.tsx
@@ -3,6 +3,7 @@
 import AppLayout from '@/components/layout/Layout';
 import { Input, App } from 'antd';
 import { useCOGViewer } from '@/hooks/useCOGViewer';
+import { logFrontend } from '@/lib/structuredLogger';
 import dynamic from 'next/dynamic';
 import 'leaflet/dist/leaflet.css';
 
@@ -36,6 +37,7 @@ const CogViewerClient = function CogViewerClient() {
             onSearch={(url) => {
               const trimmedUrl = url.trim();
               if (!trimmedUrl) {
+                logFrontend('warn', 'cog.viewer.search_missing_url');
                 message.error('Please enter a valid URL.');
                 return;
               }

--- a/app/api/frontend-logs/route.ts
+++ b/app/api/frontend-logs/route.ts
@@ -48,27 +48,16 @@ const isValidFrontendLogEntry = (value: unknown): value is FrontendLogEntry => {
 
   const { level, event, details, clientTimestamp } = value;
 
-  if (typeof level !== 'string' || !ALLOWED_LOG_LEVELS.has(level)) {
-    return false;
-  }
+  let valid = true;
 
-  if (typeof event !== 'string' || event.trim() === '') {
-    return false;
-  }
+  if (
+    typeof level !== 'string' || !ALLOWED_LOG_LEVELS.has(level) ||
+    typeof event !== 'string' || event.trim() === '' ||
+    !isRecord(details) || !Object.values(details).every(isJsonValue) ||
+    typeof clientTimestamp !== 'string' || clientTimestamp.trim() === ''
+  ) valid = false;
 
-  if (!isRecord(details)) {
-    return false;
-  }
-
-  if (!Object.values(details).every((item) => isJsonValue(item))) {
-    return false;
-  }
-
-  if (typeof clientTimestamp !== 'string' || clientTimestamp.trim() === '') {
-    return false;
-  }
-
-  return true;
+  return valid;
 };
 
 export async function POST(request: NextRequest) {

--- a/app/api/frontend-logs/route.ts
+++ b/app/api/frontend-logs/route.ts
@@ -1,0 +1,180 @@
+import { auth } from '@/auth';
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  createRequestLogContext,
+  type FrontendLogEntry,
+  type JsonValue,
+  logRequestEnd,
+  logRequestError,
+  logRequestStart,
+  logStructured,
+  summarizeSession,
+} from '@/lib/structuredLogger';
+import { validateFrontendLogOrigin } from '@/lib/frontendLogOriginGuard';
+
+const MAX_LOGS_PER_REQUEST = 20;
+const MAX_CONTENT_LENGTH_BYTES = 100_000;
+const ALLOWED_LOG_LEVELS = new Set(['debug', 'info', 'warn', 'error']);
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+};
+
+const isJsonValue = (value: unknown): value is JsonValue => {
+  if (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  ) {
+    return true;
+  }
+
+  if (Array.isArray(value)) {
+    return value.every((item) => isJsonValue(item));
+  }
+
+  if (isRecord(value)) {
+    return Object.values(value).every((item) => isJsonValue(item));
+  }
+
+  return false;
+};
+
+const isValidFrontendLogEntry = (value: unknown): value is FrontendLogEntry => {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  const { level, event, details, clientTimestamp } = value;
+
+  if (typeof level !== 'string' || !ALLOWED_LOG_LEVELS.has(level)) {
+    return false;
+  }
+
+  if (typeof event !== 'string' || event.trim() === '') {
+    return false;
+  }
+
+  if (!isRecord(details)) {
+    return false;
+  }
+
+  if (!Object.values(details).every((item) => isJsonValue(item))) {
+    return false;
+  }
+
+  if (typeof clientTimestamp !== 'string' || clientTimestamp.trim() === '') {
+    return false;
+  }
+
+  return true;
+};
+
+export async function POST(request: NextRequest) {
+  const logContext = createRequestLogContext(request, '/api/frontend-logs');
+  logRequestStart(logContext, { target: 'frontend-log-ingest' });
+
+  try {
+    const originGuard = validateFrontendLogOrigin(
+      request.headers,
+      process.env.NODE_ENV === 'production'
+    );
+    if (!originGuard.allowed) {
+      logRequestEnd(logContext, originGuard.status, {
+        reason: originGuard.reason,
+      });
+      return NextResponse.json(
+        { error: 'Origin validation failed' },
+        { status: originGuard.status }
+      );
+    }
+
+    const contentLengthRaw = request.headers.get('content-length');
+    const contentLength = contentLengthRaw ? Number(contentLengthRaw) : 0;
+
+    if (
+      Number.isFinite(contentLength) &&
+      contentLength > MAX_CONTENT_LENGTH_BYTES
+    ) {
+      logRequestEnd(logContext, 413, {
+        reason: 'payload_too_large',
+        contentLength,
+      });
+      return NextResponse.json({ error: 'Payload too large' }, { status: 413 });
+    }
+
+    const body = await request.json();
+    if (!isRecord(body) || !Array.isArray(body.logs)) {
+      logRequestEnd(logContext, 400, {
+        reason: 'invalid_request_body',
+      });
+      return NextResponse.json(
+        { error: 'Request body must include a logs array' },
+        { status: 400 }
+      );
+    }
+
+    if (body.logs.length === 0 || body.logs.length > MAX_LOGS_PER_REQUEST) {
+      logRequestEnd(logContext, 400, {
+        reason: 'invalid_log_count',
+        logCount: body.logs.length,
+      });
+      return NextResponse.json(
+        {
+          error: `Logs array must contain between 1 and ${MAX_LOGS_PER_REQUEST} entries`,
+        },
+        { status: 400 }
+      );
+    }
+
+    const validLogs = body.logs.filter((entry): entry is FrontendLogEntry =>
+      isValidFrontendLogEntry(entry)
+    );
+
+    if (validLogs.length === 0) {
+      logRequestEnd(logContext, 400, {
+        reason: 'no_valid_logs',
+      });
+      return NextResponse.json(
+        { error: 'No valid log entries found' },
+        { status: 400 }
+      );
+    }
+
+    const session = await auth();
+    const droppedCount = body.logs.length - validLogs.length;
+
+    for (const frontendLog of validLogs) {
+      logStructured(frontendLog.level, frontendLog.event, {
+        ...frontendLog.details,
+        source: 'frontend',
+        clientTimestamp: frontendLog.clientTimestamp,
+        ...(session ? summarizeSession(session) : { hasSession: false }),
+      });
+    }
+
+    logRequestEnd(logContext, 202, {
+      ingestedCount: validLogs.length,
+      droppedCount,
+    });
+
+    return NextResponse.json(
+      {
+        accepted: true,
+        ingestedCount: validLogs.length,
+        droppedCount,
+      },
+      { status: 202 }
+    );
+  } catch (error) {
+    logRequestError(logContext, error, {
+      reason: 'frontend_log_ingest_failed',
+      status: 500,
+    });
+    return NextResponse.json(
+      { error: 'Unable to ingest frontend logs' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/frontend-logs/route.ts
+++ b/app/api/frontend-logs/route.ts
@@ -20,13 +20,7 @@ const isRecord = (value: unknown): value is Record<string, unknown> => {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 };
 
-const isJsonValue = (value: unknown): value is JsonValue => {
-  if (
-    value === null ||
-    typeof value === 'string' ||
-    typeof value === 'number' ||
-    typeof value === 'boolean'
-  ) {
+  if (value === null || ['string', 'number', 'boolean'].includes(typeof value)) {
     return true;
   }
 

--- a/app/api/frontend-logs/route.ts
+++ b/app/api/frontend-logs/route.ts
@@ -20,7 +20,11 @@ const isRecord = (value: unknown): value is Record<string, unknown> => {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 };
 
-  if (value === null || ['string', 'number', 'boolean'].includes(typeof value)) {
+const isJsonValue = (value: unknown): value is JsonValue => {
+  if (
+    value === null ||
+    ['string', 'number', 'boolean'].includes(typeof value)
+  ) {
     return true;
   }
 
@@ -45,11 +49,16 @@ const isValidFrontendLogEntry = (value: unknown): value is FrontendLogEntry => {
   let valid = true;
 
   if (
-    typeof level !== 'string' || !ALLOWED_LOG_LEVELS.has(level) ||
-    typeof event !== 'string' || event.trim() === '' ||
-    !isRecord(details) || !Object.values(details).every(isJsonValue) ||
-    typeof clientTimestamp !== 'string' || clientTimestamp.trim() === ''
-  ) valid = false;
+    typeof level !== 'string' ||
+    !ALLOWED_LOG_LEVELS.has(level) ||
+    typeof event !== 'string' ||
+    event.trim() === '' ||
+    !isRecord(details) ||
+    !Object.values(details).every(isJsonValue) ||
+    typeof clientTimestamp !== 'string' ||
+    clientTimestamp.trim() === ''
+  )
+    valid = false;
 
   return valid;
 };

--- a/app/api/frontend-logs/route.ts
+++ b/app/api/frontend-logs/route.ts
@@ -63,65 +63,105 @@ const isValidFrontendLogEntry = (value: unknown): value is FrontendLogEntry => {
   return valid;
 };
 
+const validateOriginOrRespond = (
+  request: NextRequest,
+  logContext: ReturnType<typeof createRequestLogContext>
+): NextResponse | null => {
+  const originGuard = validateFrontendLogOrigin(
+    request.headers,
+    process.env.NODE_ENV === 'production'
+  );
+
+  if (!originGuard.allowed) {
+    logRequestEnd(logContext, originGuard.status, {
+      reason: originGuard.reason,
+    });
+    return NextResponse.json(
+      { error: 'Origin validation failed' },
+      { status: originGuard.status }
+    );
+  }
+
+  return null;
+};
+
+const validateContentLengthOrRespond = (
+  request: NextRequest,
+  logContext: ReturnType<typeof createRequestLogContext>
+): NextResponse | null => {
+  const contentLengthRaw = request.headers.get('content-length');
+  const contentLength = contentLengthRaw ? Number(contentLengthRaw) : 0;
+
+  if (
+    Number.isFinite(contentLength) &&
+    contentLength > MAX_CONTENT_LENGTH_BYTES
+  ) {
+    logRequestEnd(logContext, 413, {
+      reason: 'payload_too_large',
+      contentLength,
+    });
+    return NextResponse.json({ error: 'Payload too large' }, { status: 413 });
+  }
+
+  return null;
+};
+
+const parseAndValidateLogsOrRespond = (
+  body: unknown,
+  logContext: ReturnType<typeof createRequestLogContext>
+): { logs: unknown[] } | NextResponse => {
+  if (!isRecord(body) || !Array.isArray(body.logs)) {
+    logRequestEnd(logContext, 400, {
+      reason: 'invalid_request_body',
+    });
+    return NextResponse.json(
+      { error: 'Request body must include a logs array' },
+      { status: 400 }
+    );
+  }
+
+  if (body.logs.length === 0 || body.logs.length > MAX_LOGS_PER_REQUEST) {
+    logRequestEnd(logContext, 400, {
+      reason: 'invalid_log_count',
+      logCount: body.logs.length,
+    });
+    return NextResponse.json(
+      {
+        error: `Logs array must contain between 1 and ${MAX_LOGS_PER_REQUEST} entries`,
+      },
+      { status: 400 }
+    );
+  }
+
+  return { logs: body.logs };
+};
+
 export async function POST(request: NextRequest) {
   const logContext = createRequestLogContext(request, '/api/frontend-logs');
   logRequestStart(logContext, { target: 'frontend-log-ingest' });
 
   try {
-    const originGuard = validateFrontendLogOrigin(
-      request.headers,
-      process.env.NODE_ENV === 'production'
-    );
-    if (!originGuard.allowed) {
-      logRequestEnd(logContext, originGuard.status, {
-        reason: originGuard.reason,
-      });
-      return NextResponse.json(
-        { error: 'Origin validation failed' },
-        { status: originGuard.status }
-      );
+    const originValidationError = validateOriginOrRespond(request, logContext);
+    if (originValidationError) {
+      return originValidationError;
     }
 
-    const contentLengthRaw = request.headers.get('content-length');
-    const contentLength = contentLengthRaw ? Number(contentLengthRaw) : 0;
-
-    if (
-      Number.isFinite(contentLength) &&
-      contentLength > MAX_CONTENT_LENGTH_BYTES
-    ) {
-      logRequestEnd(logContext, 413, {
-        reason: 'payload_too_large',
-        contentLength,
-      });
-      return NextResponse.json({ error: 'Payload too large' }, { status: 413 });
+    const contentLengthValidationError = validateContentLengthOrRespond(
+      request,
+      logContext
+    );
+    if (contentLengthValidationError) {
+      return contentLengthValidationError;
     }
 
     const body = await request.json();
-    if (!isRecord(body) || !Array.isArray(body.logs)) {
-      logRequestEnd(logContext, 400, {
-        reason: 'invalid_request_body',
-      });
-      return NextResponse.json(
-        { error: 'Request body must include a logs array' },
-        { status: 400 }
-      );
+    const parsedLogs = parseAndValidateLogsOrRespond(body, logContext);
+    if (parsedLogs instanceof NextResponse) {
+      return parsedLogs;
     }
 
-    if (body.logs.length === 0 || body.logs.length > MAX_LOGS_PER_REQUEST) {
-      logRequestEnd(logContext, 400, {
-        reason: 'invalid_log_count',
-        logCount: body.logs.length,
-      });
-      return NextResponse.json(
-        {
-          error: `Logs array must contain between 1 and ${MAX_LOGS_PER_REQUEST} entries`,
-        },
-        { status: 400 }
-      );
-    }
-
-    const validLogs = body.logs.filter((entry): entry is FrontendLogEntry =>
-      isValidFrontendLogEntry(entry)
+    const validLogs = parsedLogs.logs.filter(
+      (entry): entry is FrontendLogEntry => isValidFrontendLogEntry(entry)
     );
 
     if (validLogs.length === 0) {
@@ -135,7 +175,7 @@ export async function POST(request: NextRequest) {
     }
 
     const session = await auth();
-    const droppedCount = body.logs.length - validLogs.length;
+    const droppedCount = parsedLogs.logs.length - validLogs.length;
 
     for (const frontendLog of validLogs) {
       logStructured(frontendLog.level, frontendLog.event, {

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -4,12 +4,14 @@ import React from 'react';
 import { SessionProvider } from 'next-auth/react';
 import { ConfigProvider, App } from 'antd';
 import { TenantProvider } from '@/app/contexts/TenantContext';
+import { FrontendErrorListeners } from '@/components/error-boundaries/FrontendErrorListeners';
 import theme from '@/theme/themeConfig';
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <ConfigProvider theme={theme}>
       <App>
+        <FrontendErrorListeners />
         <SessionProvider>
           <TenantProvider>{children}</TenantProvider>
         </SessionProvider>

--- a/components/COGViewer/COGControlsForm.tsx
+++ b/components/COGViewer/COGControlsForm.tsx
@@ -12,6 +12,7 @@ import {
   Input,
   Divider,
 } from 'antd';
+import { logFrontendError } from '@/lib/structuredLogger';
 
 const { Option } = Select;
 const { Title } = Typography;
@@ -106,7 +107,9 @@ const COGControlsForm: React.FC<COGControlsFormProps> = ({
       const data = await response.json();
       setColorMapsList(['Internal', ...data.colorMaps]);
     } catch (error) {
-      console.error('Failed to fetch color maps:', error);
+      logFrontendError('cog.controls.fetch_colormaps_failed', error, {
+        endpoint: 'raster/colorMaps',
+      });
       setColorMapsList(['Internal']);
     }
   };

--- a/components/COGViewer/COGDrawerViewer.tsx
+++ b/components/COGViewer/COGDrawerViewer.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef } from 'react';
 import { Drawer, Button } from 'antd';
 import { useCOGViewer } from '@/hooks/useCOGViewer';
 import dynamic from 'next/dynamic';
+import { logFrontendError } from '@/lib/structuredLogger';
 
 // Dynamically load the COGViewerContent component to prevent SSR issues
 const COGViewerContent = dynamic(
@@ -48,8 +49,9 @@ const COGDrawerViewer: React.FC<COGDrawerViewerProps> = ({
 
   const handleAccept = () => {
     if (!onAcceptRenderOptions) {
-      console.error(
-        '❌ onAcceptRenderOptions function is missing in COGDrawerViewer.'
+      logFrontendError(
+        'cog.drawer.accept_missing_callback',
+        'onAcceptRenderOptions function is missing in COGDrawerViewer.'
       );
       return;
     }

--- a/components/COGViewer/COGViewerContent.tsx
+++ b/components/COGViewer/COGViewerContent.tsx
@@ -4,6 +4,7 @@ import { Map as LeafletMap } from 'leaflet';
 
 import COGControlsForm from './COGControlsForm';
 import RenderingOptionsModal from './RenderingOptionsModal';
+import { logFrontendError } from '@/lib/structuredLogger';
 
 // Dynamically import react-leaflet components to avoid SSR issues
 import dynamic from 'next/dynamic';
@@ -153,7 +154,10 @@ const COGViewerContent: React.FC<COGViewerContentProps> = ({
                 noDataValue
               );
             } else {
-              console.error('Cannot update tile layer: COG URL is null.');
+              logFrontendError(
+                'cog.viewer.update_tile_layer_missing_cog_url',
+                'Cannot update tile layer: COG URL is null.'
+              );
             }
           }}
           onViewRenderingOptions={() => setIsModalVisible(true)}

--- a/components/COGViewer/COGViewerContent.tsx
+++ b/components/COGViewer/COGViewerContent.tsx
@@ -5,7 +5,7 @@ import { Map as LeafletMap } from 'leaflet';
 
 import COGControlsForm from './COGControlsForm';
 import RenderingOptionsModal from './RenderingOptionsModal';
-import { logFrontendError } from '@/lib/structuredLogger';
+import { logFrontend, logFrontendError } from '@/lib/structuredLogger';
 
 // Dynamically import react-leaflet components to avoid SSR issues
 import dynamic from 'next/dynamic';
@@ -100,7 +100,7 @@ const COGViewerContent: React.FC<COGViewerContentProps> = ({
   // Automatically adjust map size when container resizes
   useEffect(() => {
     if (!containerRef.current) {
-      console.warn('Map container ref not available for ResizeObserver');
+      logFrontend('warn', 'cog.viewer.resize_observer_missing_container_ref');
       return;
     }
 

--- a/components/COGViewer/RenderingOptionsModal.tsx
+++ b/components/COGViewer/RenderingOptionsModal.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Button, Modal, App } from 'antd';
 import dynamic from 'next/dynamic';
 import '@uiw/react-textarea-code-editor/dist.css';
+import { logFrontendError } from '@/lib/structuredLogger';
 
 const CodeEditor = dynamic(
   () => import('@uiw/react-textarea-code-editor').then((mod) => mod.default),
@@ -61,7 +62,7 @@ const RenderingOptionsModal: React.FC<RenderingOptionsModalProps> = ({
       setCopied(true);
       message.success('Rendering options copied to clipboard!');
     } catch (error) {
-      console.error('Failed to copy to clipboard:', error);
+      logFrontendError('cog.rendering_options.copy_failed', error);
       message.error('Failed to copy rendering options.');
     }
   };

--- a/components/error-boundaries/APIErrorBoundary.tsx
+++ b/components/error-boundaries/APIErrorBoundary.tsx
@@ -45,7 +45,7 @@ export class APIErrorBoundary extends Component<Props, State> {
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     logFrontendError('error_boundary.api.caught', error, {
-      componentStack: errorInfo.componentStack,
+      componentStack: errorInfo.componentStack ?? null,
     });
 
     if (this.props.onError) {

--- a/components/error-boundaries/APIErrorBoundary.tsx
+++ b/components/error-boundaries/APIErrorBoundary.tsx
@@ -3,6 +3,7 @@
 import React, { Component, ErrorInfo, ReactNode } from 'react';
 import { Alert, Button, Space, Spin } from 'antd';
 import { ReloadOutlined, BugOutlined } from '@ant-design/icons';
+import { logFrontendError } from '@/lib/structuredLogger';
 
 interface Props {
   children: ReactNode;
@@ -43,7 +44,9 @@ export class APIErrorBoundary extends Component<Props, State> {
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    console.error('APIErrorBoundary caught an error:', error, errorInfo);
+    logFrontendError('error_boundary.api.caught', error, {
+      componentStack: errorInfo.componentStack,
+    });
 
     if (this.props.onError) {
       this.props.onError(error, errorInfo);
@@ -66,7 +69,7 @@ export class APIErrorBoundary extends Component<Props, State> {
         });
       }, 500);
     } catch (retryError) {
-      console.error('Retry failed:', retryError);
+      logFrontendError('error_boundary.api.retry_failed', retryError);
       this.setState({ isRetrying: false });
     }
   };

--- a/components/error-boundaries/FrontendErrorListeners.tsx
+++ b/components/error-boundaries/FrontendErrorListeners.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useEffect } from 'react';
+import { logFrontendError } from '@/lib/structuredLogger';
+
+export function FrontendErrorListeners() {
+  useEffect(() => {
+    const onError = (event: ErrorEvent) => {
+      logFrontendError(
+        'window.error',
+        event.error ?? event.message ?? 'Unknown window error',
+        {
+          source: event.filename,
+          line: event.lineno,
+          column: event.colno,
+        }
+      );
+    };
+
+    const onUnhandledRejection = (event: PromiseRejectionEvent) => {
+      logFrontendError('window.unhandled_rejection', event.reason, {
+        source: 'promise',
+      });
+    };
+
+    window.addEventListener('error', onError);
+    window.addEventListener('unhandledrejection', onUnhandledRejection);
+
+    return () => {
+      window.removeEventListener('error', onError);
+      window.removeEventListener('unhandledrejection', onUnhandledRejection);
+    };
+  }, []);
+
+  return null;
+}

--- a/components/error-boundaries/TenantErrorBoundary.tsx
+++ b/components/error-boundaries/TenantErrorBoundary.tsx
@@ -40,7 +40,7 @@ export class TenantErrorBoundary extends Component<Props, State> {
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     logFrontendError('error_boundary.tenant.caught', error, {
-      componentStack: errorInfo.componentStack,
+      componentStack: errorInfo.componentStack ?? null,
     });
 
     this.setState({

--- a/components/error-boundaries/TenantErrorBoundary.tsx
+++ b/components/error-boundaries/TenantErrorBoundary.tsx
@@ -3,6 +3,7 @@
 import React, { Component, ErrorInfo, ReactNode } from 'react';
 import { Alert, Button, Space, Typography } from 'antd';
 import { ReloadOutlined, HomeOutlined } from '@ant-design/icons';
+import { logFrontendError } from '@/lib/structuredLogger';
 
 const { Paragraph } = Typography;
 
@@ -38,7 +39,9 @@ export class TenantErrorBoundary extends Component<Props, State> {
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    console.error('TenantErrorBoundary caught an error:', error, errorInfo);
+    logFrontendError('error_boundary.tenant.caught', error, {
+      componentStack: errorInfo.componentStack,
+    });
 
     this.setState({
       error,

--- a/components/ingestion/CreationFormManager.tsx
+++ b/components/ingestion/CreationFormManager.tsx
@@ -7,6 +7,7 @@ import DatasetIngestionForm from '@/components/ingestion/DatasetIngestionForm';
 import CollectionIngestionForm from '@/components/ingestion/CollectionIngestionForm';
 import { useCogValidation } from '@/hooks/useCogValidation';
 import { getTenantFieldKey } from '@/utils/tenantField';
+import { logFrontendError } from '@/lib/structuredLogger';
 
 const { Title } = Typography;
 const { TextArea } = Input;
@@ -42,32 +43,38 @@ const CreationFormManager: React.FC<CreationFormManagerProps> = ({
     validateFormDataCog,
   } = useCogValidation();
 
-  const handleFormSubmit = useCallback(async (data?: Record<string, unknown>) => {
-    if (!data) {
-      console.error('No form data provided.');
-      return;
-    }
+  const handleFormSubmit = useCallback(
+    async (data?: Record<string, unknown>) => {
+      if (!data) {
+        logFrontendError(
+          'ingestion.creation.submit_missing_form_data',
+          'No form data provided.'
+        );
+        return;
+      }
 
-    // Clean up the form data
-    const cleanedData = { ...data };
-    const tenantFieldKey = getTenantFieldKey();
-    if (
-      Array.isArray(cleanedData[tenantFieldKey]) &&
-      cleanedData[tenantFieldKey].length === 0
-    ) {
-      delete cleanedData[tenantFieldKey];
-    }
+      // Clean up the form data
+      const cleanedData = { ...data };
+      const tenantFieldKey = getTenantFieldKey();
+      if (
+        Array.isArray(cleanedData[tenantFieldKey]) &&
+        cleanedData[tenantFieldKey].length === 0
+      ) {
+        delete cleanedData[tenantFieldKey];
+      }
 
-    setStagedFormData(cleanedData);
+      setStagedFormData(cleanedData);
 
-    const isValid = await validateFormDataCog(cleanedData, formType);
-    if (!isValid) {
-      showCogValidationModal();
-      return;
-    }
+      const isValid = await validateFormDataCog(cleanedData, formType);
+      if (!isValid) {
+        showCogValidationModal();
+        return;
+      }
 
-    setIsModalVisible(true);
-  }, [formType, validateFormDataCog, showCogValidationModal]);
+      setIsModalVisible(true);
+    },
+    [formType, validateFormDataCog, showCogValidationModal]
+  );
 
   const handleCogValidationContinue = () => {
     hideCogValidationModal();
@@ -76,7 +83,10 @@ const CreationFormManager: React.FC<CreationFormManagerProps> = ({
 
   const handleFinalSubmit = () => {
     if (!stagedFormData) {
-      console.error('No staged form data available for submission.');
+      logFrontendError(
+        'ingestion.creation.final_submit_missing_staged_data',
+        'No staged form data available for submission.'
+      );
       setIsModalVisible(false);
       return;
     }
@@ -112,7 +122,9 @@ const CreationFormManager: React.FC<CreationFormManagerProps> = ({
         setStatus('success');
       })
       .catch((error) => {
-        console.error(error);
+        logFrontendError('ingestion.creation.submit_request_failed', error, {
+          endpoint: 'api/create-ingest',
+        });
         setStatus('error');
       })
       .finally(() => {

--- a/components/ingestion/EditFormManager.tsx
+++ b/components/ingestion/EditFormManager.tsx
@@ -8,6 +8,7 @@ import { Button, Card, Space, Alert, Modal, Spin } from 'antd';
 import { useCogValidation } from '@/hooks/useCogValidation';
 import { VirtualDiffViewer } from 'virtual-react-json-diff';
 import { sanitizeFormData } from '@/utils/stacSanitization';
+import { logFrontendError } from '@/lib/structuredLogger';
 
 interface EditFormManagerProps {
   formType: 'dataset' | 'collection' | 'existingCollection';
@@ -101,7 +102,10 @@ const EditFormManager: React.FC<EditFormManagerProps> = ({
 
   const onFormDataSubmit = async (formData?: Record<string, unknown>) => {
     if (!formData) {
-      console.error('No form data provided.');
+      logFrontendError(
+        'ingestion.edit.submit_missing_form_data',
+        'No form data provided.'
+      );
       return;
     }
 
@@ -113,7 +117,10 @@ const EditFormManager: React.FC<EditFormManagerProps> = ({
     setIsDiffModalVisible(false);
 
     if (!pendingFormData) {
-      console.error('No pending form data.');
+      logFrontendError(
+        'ingestion.edit.confirm_missing_pending_form_data',
+        'No pending form data.'
+      );
       return;
     }
 
@@ -149,7 +156,8 @@ const EditFormManager: React.FC<EditFormManagerProps> = ({
     if (formType === 'existingCollection') {
       const collectionId = formData.id as string;
       if (!collectionId) {
-        console.error(
+        logFrontendError(
+          'ingestion.edit.missing_collection_id',
           'Collection ID is required for existing collection updates'
         );
         setApiErrorMessage('Collection ID is missing');
@@ -187,7 +195,9 @@ const EditFormManager: React.FC<EditFormManagerProps> = ({
         setStatus('success');
       })
       .catch((error) => {
-        console.error(error);
+        logFrontendError('ingestion.edit.submit_request_failed', error, {
+          endpoint: url,
+        });
         setApiErrorMessage('A network error occurred. Please try again.');
         setStatus('error');
       });

--- a/components/rjsf-components/ObjectFieldTemplate.tsx
+++ b/components/rjsf-components/ObjectFieldTemplate.tsx
@@ -24,6 +24,7 @@ import {
 } from 'antd/lib/config-provider/context';
 import Button from 'antd/lib/button';
 import { CloudUploadOutlined } from '@ant-design/icons';
+import { logFrontendError } from '@/lib/structuredLogger';
 
 import ThumbnailUploaderDrawer from '@/components/thumbnails/ThumbnailUploaderDrawer';
 import DiscoveryItemObjectFieldTemplate from './DiscoveryItemObjectFieldTemplate'; // Import the specific template
@@ -102,7 +103,10 @@ export default function ObjectFieldTemplate<
       !formContextWithUpdate ||
       typeof formContextWithUpdate.updateFormData !== 'function'
     ) {
-      console.error('formContext or updateFormData is not available.');
+      logFrontendError(
+        'rjsf.object_template.form_context_missing_update',
+        'formContext or updateFormData is not available.'
+      );
       return;
     }
 

--- a/components/rjsf-components/TestableUrlWidget.tsx
+++ b/components/rjsf-components/TestableUrlWidget.tsx
@@ -5,6 +5,7 @@ import Button from 'antd/lib/button';
 import Typography from 'antd/lib/typography';
 import { useState, useEffect, useRef } from 'react';
 import { CheckOutlined, CloseCircleOutlined } from '@ant-design/icons';
+import { logFrontendError } from '@/lib/structuredLogger';
 
 type ValidationState = 'idle' | 'loading' | 'validated' | 'error';
 
@@ -51,7 +52,9 @@ export const TestableUrlWidget = ({
         setValidationState('error');
       }
     } catch (err) {
-      console.error('Validation API request failed', err);
+      logFrontendError('rjsf.testable_url.validation_request_failed', err, {
+        endpoint: 'raster/cog/validate',
+      });
       setValidationState('error');
     }
   };

--- a/components/thumbnails/ThumbnailUploader.tsx
+++ b/components/thumbnails/ThumbnailUploader.tsx
@@ -17,6 +17,7 @@ import {
   ExclamationCircleOutlined,
   CopyOutlined,
 } from '@ant-design/icons';
+import { logFrontendError } from '@/lib/structuredLogger';
 
 const { Title, Paragraph, Link } = Typography;
 
@@ -168,7 +169,9 @@ function ThumbnailUploader({
       await proceedWithUpload(file, uploadUrl, fileUrl, progressHandler);
     } catch (error) {
       loadingMessage();
-      console.error('Upload failed:', error);
+      logFrontendError('thumbnail.upload.request_failed', error, {
+        endpoint: '/api/upload-url',
+      });
       message.error('Upload failed, please try again.');
       setUploadingFile(null);
       clearErrorsWithAnimation();
@@ -195,7 +198,9 @@ function ThumbnailUploader({
       setUploadedFile({ name: file.name, url: fileUrl });
     } catch (error) {
       closeUploadingMessage();
-      console.error('Upload failed:', error);
+      logFrontendError('thumbnail.upload.s3_put_failed', error, {
+        destination: 's3',
+      });
       message.error('Upload failed, please try again.');
       setUploadingFile(null);
     }
@@ -249,7 +254,7 @@ function ThumbnailUploader({
       await navigator.clipboard.writeText(uploadedFile.url);
       setCopied(true);
     } catch (error) {
-      console.error('Failed to copy to clipboard:', error);
+      logFrontendError('thumbnail.upload.copy_url_failed', error);
     }
   };
 

--- a/components/thumbnails/ThumbnailUploader.tsx
+++ b/components/thumbnails/ThumbnailUploader.tsx
@@ -110,6 +110,10 @@ function ThumbnailUploader({
 
   const handleUpload = async ({ file, onProgress }: UploadHandlerOptions) => {
     if (!(file instanceof File)) {
+      logFrontendError(
+        'thumbnail.upload.invalid_selected_file',
+        'No valid file selected for thumbnail upload.'
+      );
       message.error('No valid file selected. Please try again.');
       return;
     }
@@ -117,6 +121,9 @@ function ThumbnailUploader({
     const progressHandler = onProgress || (() => {});
 
     if (!ALLOWED_FILE_TYPES.includes(file.type)) {
+      logFrontendError('thumbnail.upload.invalid_file_format', {
+        fileType: file.type || 'unknown',
+      });
       message.error('Invalid file format. Please upload a JPG or PNG image.');
       return;
     }

--- a/components/ui/ExtensionManager.tsx
+++ b/components/ui/ExtensionManager.tsx
@@ -9,6 +9,7 @@ import {
   App,
   Button,
 } from 'antd';
+import { logFrontend } from '@/lib/structuredLogger';
 
 interface ExtensionManagerProps {
   extensionFields: Record<string, { title: string }>;
@@ -31,6 +32,7 @@ const ExtensionManager: React.FC<ExtensionManagerProps> = ({
       onAddExtension(value);
       setSearchUrl('');
     } else {
+      logFrontend('warn', 'stac.extensions.search_missing_url');
       message.error('Please enter a URL.');
     }
   };

--- a/components/ui/JSONEditor.tsx
+++ b/components/ui/JSONEditor.tsx
@@ -8,7 +8,7 @@ import AdditionalPropertyCard from '@/components/rjsf-components/AdditionalPrope
 import dynamic from 'next/dynamic';
 import '@uiw/react-textarea-code-editor/dist.css';
 import { JSONSchema7 } from 'json-schema';
-import { logFrontendError } from '@/lib/structuredLogger';
+import { logFrontend, logFrontendError } from '@/lib/structuredLogger';
 
 const CodeEditor = dynamic(
   () => import('@uiw/react-textarea-code-editor').then((mod) => mod.default),
@@ -373,9 +373,7 @@ const JSONEditor: React.FC<JSONEditorProps> = ({
           dashboard: JSON.parse(value.renders.dashboard),
         };
       } catch {
-        console.warn(
-          "Could not parse 'renders.dashboard' as JSON, leaving it as-is."
-        );
+        logFrontend('warn', 'json_editor.parse_dashboard_as_json_failed');
       }
     }
     setEditorValue(JSON.stringify(updatedValue, null, 2));

--- a/components/ui/JSONEditor.tsx
+++ b/components/ui/JSONEditor.tsx
@@ -8,6 +8,7 @@ import AdditionalPropertyCard from '@/components/rjsf-components/AdditionalPrope
 import dynamic from 'next/dynamic';
 import '@uiw/react-textarea-code-editor/dist.css';
 import { JSONSchema7 } from 'json-schema';
+import { logFrontendError } from '@/lib/structuredLogger';
 
 const CodeEditor = dynamic(
   () => import('@uiw/react-textarea-code-editor').then((mod) => mod.default),
@@ -155,7 +156,7 @@ const JSONEditor: React.FC<JSONEditorProps> = ({
             2
           );
         } catch (e) {
-          console.error('Error stringifying renders.dashboard:', e);
+          logFrontendError('json_editor.stringify_renders_dashboard_failed', e);
           setSchemaErrors(['Invalid JSON object in renders.dashboard.']);
           return;
         }
@@ -342,7 +343,7 @@ const JSONEditor: React.FC<JSONEditorProps> = ({
 
       validateAndApply(parsedValue);
     } catch (err) {
-      console.error('error', err);
+      logFrontendError('json_editor.apply_changes_invalid_json', err);
       setJsonError('Invalid JSON format.');
       setSchemaErrors([]);
     }

--- a/docs/deployment/cloudwatch-logs.md
+++ b/docs/deployment/cloudwatch-logs.md
@@ -36,6 +36,19 @@ Common auth/proxy events you may also see:
 - `auth.token.refresh_failed`
 - `auth.tenants.fetch_failed`
 
+Frontend structured error events are also emitted with the same logger helpers, prefixed as `frontend.*` (for example `frontend.error_boundary.api.caught` and `frontend.thumbnail.upload.request_failed`).
+
+Global browser listeners in [components/error-boundaries/FrontendErrorListeners.tsx](../../components/error-boundaries/FrontendErrorListeners.tsx) also capture:
+
+- `frontend.window.error`
+- `frontend.window.unhandled_rejection`
+
+When frontend forwarding is enabled, browser logs are posted to [app/api/frontend-logs/route.ts](../../app/api/frontend-logs/route.ts), then written by the server logger so they are included in CloudWatch streams with the same JSON format.
+
+- These frontend events appear in browser devtools logs.
+- They are shipped to CloudWatch through the server-side ingest route.
+- In production, the ingest route enforces an origin guard by comparing `origin` against `x-forwarded-host`/`host` (Amplify-safe), and rejects cross-site submissions.
+
 ## Log-Level Behavior (Very Important)
 
 The logger is intentionally quieter in non-debug mode.
@@ -51,10 +64,12 @@ The logger is intentionally quieter in non-debug mode.
   - `api.request.start` is emitted.
   - Successful request-end logs are emitted.
   - Default lowest level becomes `debug` unless overridden with `LOG_LEVEL`.
+  - Frontend logger debug verbosity is also enabled via the public mapping `NEXT_PUBLIC_ENABLE_DEBUG_LOGGING`.
 
 Environment variables:
 
 - `ENABLE_DEBUG_LOGGING=true|false`
+- `NEXT_PUBLIC_ENABLE_DEBUG_LOGGING=true|false` (browser-facing flag; auto-populated from `ENABLE_DEBUG_LOGGING` in `next.config.ts` unless explicitly set)
 - `LOG_LEVEL=debug|info|warn|warning|error` (used only when debug logging is enabled)
 
 ## Finding Logs From Amplify

--- a/hooks/useCOGViewer.ts
+++ b/hooks/useCOGViewer.ts
@@ -1,6 +1,7 @@
 import { useState, useRef, useCallback } from 'react';
 import { App } from 'antd';
 import { VEDA_BACKEND_URL } from '@/config/env';
+import { logFrontendError } from '@/lib/structuredLogger';
 import { Map as LeafletMap } from 'leaflet';
 
 type RendersType = {
@@ -64,7 +65,7 @@ const fetchTileJson = async (
 
   if (!response.ok) throw new Error('Failed to fetch tile URL');
   return response.json() as Promise<TileJsonResponse>;
-}
+};
 
 export const useCOGViewer = () => {
   const { message } = App.useApp();
@@ -122,7 +123,9 @@ export const useCOGViewer = () => {
 
         message.success('COG tile layer loaded successfully!');
       } catch (error) {
-        console.error('Error fetching tile URL:', error);
+        logFrontendError('cog.viewer.fetch_tile_url_failed', error, {
+          endpoint: 'raster/cog/WebMercatorQuad/tilejson.json',
+        });
         message.error('Failed to load tile layer.');
       } finally {
         setLoading(false);
@@ -175,7 +178,7 @@ export const useCOGViewer = () => {
                 : renders;
             mergedMetadata = { ...COGdata, ...parsedRenders };
           } catch (error) {
-            console.error('Error parsing renders:', error);
+            logFrontendError('cog.viewer.parse_renders_failed', error);
           }
         }
 

--- a/hooks/useCOGViewer.ts
+++ b/hooks/useCOGViewer.ts
@@ -1,7 +1,7 @@
 import { useState, useReducer, useRef, useCallback } from 'react';
 import { App } from 'antd';
 import { VEDA_BACKEND_URL } from '@/config/env';
-import { logFrontendError } from '@/lib/structuredLogger';
+import { logFrontend, logFrontendError } from '@/lib/structuredLogger';
 import { Map as LeafletMap } from 'leaflet';
 import {
   type ColormapType,
@@ -175,6 +175,9 @@ export const useCOGViewer = () => {
   const fetchMetadata = useCallback(
     async (url: string, renders?: string | RendersType | null) => {
       if (!url) {
+        logFrontend('warn', 'cog.viewer.metadata_missing_url', {
+          endpoint: 'raster/cog/info',
+        });
         message.error('COG URL is required');
         return;
       }
@@ -278,6 +281,10 @@ export const useCOGViewer = () => {
 
         message.success('COG metadata loaded successfully!');
       } catch (error) {
+        logFrontendError('cog.viewer.fetch_metadata_failed', error, {
+          endpoint: 'raster/cog/info',
+          hasRenders: Boolean(renders),
+        });
         if (error instanceof Error) {
           message.error(error.message);
         } else {

--- a/hooks/useCogValidation.ts
+++ b/hooks/useCogValidation.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react';
 import { VEDA_BACKEND_URL } from '@/config/env';
+import { logFrontendError } from '@/lib/structuredLogger';
 
 interface UseCogValidationReturn {
   isCogValidationModalVisible: boolean;
@@ -22,38 +23,43 @@ const validateCogUrl = async (url: string): Promise<boolean> => {
     const response = await fetch(validationApiUrl);
     return response.ok;
   } catch (err) {
-    console.error('COG validation API request failed', err);
+    logFrontendError('cog.validation.request_failed', err, {
+      endpoint: 'raster/cog/validate',
+    });
     return false;
   }
-}
+};
 
 export const useCogValidation = (): UseCogValidationReturn => {
   const [isCogValidationModalVisible, setIsCogValidationModalVisible] =
     useState(false);
   const [isValidatingCog, setIsValidatingCog] = useState(false);
 
-  const validateFormDataCog = useCallback(async (
-    formData: Record<string, unknown>,
-    formType: 'dataset' | 'collection' | 'existingCollection'
-  ): Promise<boolean> => {
-    if (formType !== 'dataset' || !formData.sample_files) {
-      return true;
-    }
+  const validateFormDataCog = useCallback(
+    async (
+      formData: Record<string, unknown>,
+      formType: 'dataset' | 'collection' | 'existingCollection'
+    ): Promise<boolean> => {
+      if (formType !== 'dataset' || !formData.sample_files) {
+        return true;
+      }
 
-    const sampleFiles = formData.sample_files as string | string[];
-    const sampleFileUrl = Array.isArray(sampleFiles)
-      ? sampleFiles[0]
-      : sampleFiles;
+      const sampleFiles = formData.sample_files as string | string[];
+      const sampleFileUrl = Array.isArray(sampleFiles)
+        ? sampleFiles[0]
+        : sampleFiles;
 
-    if (!sampleFileUrl) {
-      return true;
-    }
+      if (!sampleFileUrl) {
+        return true;
+      }
 
-    setIsValidatingCog(true);
-    const result = await validateCogUrl(sampleFileUrl);
-    setIsValidatingCog(false);
-    return result;
-  }, []);
+      setIsValidatingCog(true);
+      const result = await validateCogUrl(sampleFileUrl);
+      setIsValidatingCog(false);
+      return result;
+    },
+    []
+  );
 
   const showCogValidationModal = useCallback(() => {
     setIsCogValidationModalVisible(true);

--- a/hooks/useStacExtensions.ts
+++ b/hooks/useStacExtensions.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { App } from 'antd';
 import { JSONSchema7 } from 'json-schema';
+import { logFrontendError } from '@/lib/structuredLogger';
 
 export interface ExtensionField {
   name: string;
@@ -70,7 +71,7 @@ export function useStacExtensions({ setFormData }: UseStacExtensionsProps) {
 
         message.success(`Extension "${title}" loaded successfully.`);
       } catch (error) {
-        console.error(error);
+        logFrontendError('stac.extensions.load_failed', error, { url });
         message.error(`Could not load or parse extension from ${url}`);
       } finally {
         setUrlsToProcess((prev) => prev.filter((u) => u !== url));

--- a/hooks/useStacExtensions.ts
+++ b/hooks/useStacExtensions.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { App } from 'antd';
 import { JSONSchema7 } from 'json-schema';
-import { logFrontendError } from '@/lib/structuredLogger';
+import { logFrontend, logFrontendError } from '@/lib/structuredLogger';
 
 export interface ExtensionField {
   name: string;
@@ -55,6 +55,10 @@ export function useStacExtensions({ setFormData }: UseStacExtensionsProps) {
         }));
 
         if (fields.length === 0) {
+          logFrontend('warn', 'stac.extensions.no_fields_found', {
+            url,
+            title,
+          });
           message.warning(`No specific extension fields found in: ${title}.`);
           return;
         }
@@ -91,6 +95,10 @@ export function useStacExtensions({ setFormData }: UseStacExtensionsProps) {
 
   const addExtension = (url: string) => {
     if (!url || extensionFields[url]) {
+      logFrontend('warn', 'stac.extensions.add_invalid_or_duplicate', {
+        url,
+        isDuplicate: Boolean(url && extensionFields[url]),
+      });
       message.warning('Extension already added or URL is empty.');
       return;
     }
@@ -104,6 +112,7 @@ export function useStacExtensions({ setFormData }: UseStacExtensionsProps) {
       delete newFields[urlToRemove];
       return newFields;
     });
+    logFrontend('info', 'stac.extensions.removed', { url: urlToRemove, title });
     message.info(`"${title}" extension removed.`);
   };
 

--- a/lib/frontendLogOriginGuard.ts
+++ b/lib/frontendLogOriginGuard.ts
@@ -1,0 +1,84 @@
+export type OriginGuardResult =
+  | { allowed: true }
+  | { allowed: false; status: number; reason: string };
+
+const getPrimaryHeaderValue = (value: string | null): string | null => {
+  if (!value) {
+    return null;
+  }
+
+  const primary = value
+    .split(',')
+    .map((part) => part.trim())
+    .find((part) => part !== '');
+
+  return primary ?? null;
+};
+
+export const validateFrontendLogOrigin = (
+  headers: Headers,
+  isProduction: boolean
+): OriginGuardResult => {
+  const originHeader = headers.get('origin');
+  const forwardedHost = getPrimaryHeaderValue(headers.get('x-forwarded-host'));
+  const host = getPrimaryHeaderValue(headers.get('host'));
+  const requestHost = (forwardedHost ?? host)?.toLowerCase() ?? null;
+
+  if (!requestHost) {
+    return {
+      allowed: false,
+      status: 400,
+      reason: 'missing_request_host',
+    };
+  }
+
+  if (!originHeader) {
+    if (isProduction) {
+      return {
+        allowed: false,
+        status: 403,
+        reason: 'missing_origin_header',
+      };
+    }
+
+    return { allowed: true };
+  }
+
+  let originUrl: URL;
+  try {
+    originUrl = new URL(originHeader);
+  } catch {
+    return {
+      allowed: false,
+      status: 400,
+      reason: 'invalid_origin_header',
+    };
+  }
+
+  if (isProduction && originUrl.protocol !== 'https:') {
+    return {
+      allowed: false,
+      status: 403,
+      reason: 'non_https_origin',
+    };
+  }
+
+  if (originUrl.host.toLowerCase() !== requestHost) {
+    return {
+      allowed: false,
+      status: 403,
+      reason: 'origin_host_mismatch',
+    };
+  }
+
+  const fetchSite = headers.get('sec-fetch-site');
+  if (fetchSite && fetchSite !== 'same-origin' && fetchSite !== 'same-site') {
+    return {
+      allowed: false,
+      status: 403,
+      reason: 'cross_site_request_rejected',
+    };
+  }
+
+  return { allowed: true };
+};

--- a/lib/structuredLogger.ts
+++ b/lib/structuredLogger.ts
@@ -7,9 +7,9 @@ import {
   type Logger,
 } from '@logtape/logtape';
 
-type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 
-type JsonValue =
+export type JsonValue =
   | string
   | number
   | boolean
@@ -22,6 +22,9 @@ const REQUEST_ID_HEADERS = [
   'x-correlation-id',
   'x-amzn-trace-id',
 ];
+
+const FRONTEND_LOG_INGEST_PATH = '/api/frontend-logs';
+const DEFAULT_ENABLE_FRONTEND_LOG_FORWARDING = true;
 
 const MAX_REQUEST_ID_LENGTH = 128;
 const DEFAULT_PRODUCTION_LOG_LEVEL: LogLevel = 'warn';
@@ -46,8 +49,22 @@ interface RequestEndPayload extends RequestLogBasePayload {
 
 interface RequestErrorPayload extends RequestLogBasePayload {
   durationMs: number;
-  error: { name: string; message: string; stack?: string };
+  error: SerializableError;
   [key: string]: JsonValue;
+}
+
+export interface SerializableError {
+  [key: string]: JsonValue;
+  name: string;
+  message: string;
+  stack: string | null;
+}
+
+export interface FrontendLogEntry {
+  level: LogLevel;
+  event: string;
+  details: Record<string, JsonValue>;
+  clientTimestamp: string;
 }
 
 export interface RequestLogContext extends RequestLogBasePayload {
@@ -67,7 +84,10 @@ interface RequestLike {
   url?: string;
 }
 
-const isDebugLoggingEnabled = process.env.ENABLE_DEBUG_LOGGING === 'true';
+const isBrowserRuntime = typeof window !== 'undefined';
+const isServerDebugLoggingEnabled = process.env.ENABLE_DEBUG_LOGGING === 'true';
+const isFrontendDebugLoggingEnabled =
+  process.env.NEXT_PUBLIC_ENABLE_DEBUG_LOGGING === 'true';
 
 const LOG_LEVEL_ALIASES: Record<string, LogLevel> = {
   debug: 'debug',
@@ -87,9 +107,13 @@ const parseLogLevelFromEnv = (): LogLevel | null => {
   return LOG_LEVEL_ALIASES[raw] ?? null;
 };
 
-const configuredLogLevel: LogLevel = isDebugLoggingEnabled
-  ? (parseLogLevelFromEnv() ?? DEFAULT_DEBUG_LOG_LEVEL)
-  : DEFAULT_PRODUCTION_LOG_LEVEL;
+const configuredLogLevel: LogLevel = isBrowserRuntime
+  ? isFrontendDebugLoggingEnabled
+    ? DEFAULT_DEBUG_LOG_LEVEL
+    : DEFAULT_PRODUCTION_LOG_LEVEL
+  : isServerDebugLoggingEnabled
+    ? (parseLogLevelFromEnv() ?? DEFAULT_DEBUG_LOG_LEVEL)
+    : DEFAULT_PRODUCTION_LOG_LEVEL;
 
 const toLogTapeLevel = (level: LogLevel): LogTapeLevel => {
   if (level === 'warn') {
@@ -183,14 +207,12 @@ const pickRequestId = (headers?: HeaderLike): string => {
   return createFallbackRequestId();
 };
 
-const toSerializableError = (
-  error: unknown
-): { name: string; message: string; stack?: string } => {
+export const toSerializableError = (error: unknown): SerializableError => {
   if (error instanceof Error) {
     return {
       name: error.name,
       message: error.message,
-      stack: error.stack,
+      stack: error.stack ?? null,
     };
   }
 
@@ -206,7 +228,54 @@ const toSerializableError = (
               return '[unserializable-error]';
             }
           })(),
+    stack: null,
   };
+};
+
+const getBrowserContext = (): Record<string, JsonValue> => {
+  if (typeof window === 'undefined') {
+    return {};
+  }
+
+  return {
+    pathname: window.location.pathname,
+    href: window.location.href,
+  };
+};
+
+const shouldForwardFrontendLogs = (): boolean => {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  if (process.env.NODE_ENV === 'test') {
+    return false;
+  }
+
+  const configuredValue = process.env.NEXT_PUBLIC_FORWARD_FRONTEND_LOGS;
+  if (!configuredValue || configuredValue.trim() === '') {
+    return DEFAULT_ENABLE_FRONTEND_LOG_FORWARDING;
+  }
+
+  return configuredValue.trim().toLowerCase() === 'true';
+};
+
+const forwardFrontendLog = (entry: FrontendLogEntry): void => {
+  if (!shouldForwardFrontendLogs()) {
+    return;
+  }
+
+  void fetch(FRONTEND_LOG_INGEST_PATH, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    credentials: 'same-origin',
+    keepalive: true,
+    body: JSON.stringify({ logs: [entry] }),
+  }).catch(() => {
+    // Avoid recursive logging loops if log forwarding itself fails.
+  });
 };
 
 export const logStructured = (
@@ -238,6 +307,38 @@ export const logStructured = (
       baseLogger.info('{event}', payload);
       break;
   }
+};
+
+export const logFrontend = (
+  level: LogLevel,
+  event: string,
+  details: Record<string, JsonValue> = {}
+): void => {
+  const frontendEventName = `frontend.${event}`;
+  const payload = {
+    runtime: 'browser',
+    ...getBrowserContext(),
+    ...details,
+  };
+
+  logStructured(level, frontendEventName, payload);
+  forwardFrontendLog({
+    level,
+    event: frontendEventName,
+    details: payload,
+    clientTimestamp: new Date().toISOString(),
+  });
+};
+
+export const logFrontendError = (
+  event: string,
+  error: unknown,
+  details: Record<string, JsonValue> = {}
+): void => {
+  logFrontend('error', event, {
+    ...details,
+    error: toSerializableError(error),
+  });
 };
 
 export const createRequestLogContext = (
@@ -294,7 +395,7 @@ export const logRequestStart = (
   context: RequestLogContext,
   details: Record<string, JsonValue> = {}
 ): void => {
-  if (!isDebugLoggingEnabled) {
+  if (!isServerDebugLoggingEnabled) {
     return;
   }
 
@@ -310,7 +411,7 @@ export const logRequestEnd = (
   status: number,
   details: Record<string, JsonValue> = {}
 ): void => {
-  if (status < 400 && !isDebugLoggingEnabled) {
+  if (status < 400 && !isServerDebugLoggingEnabled) {
     return;
   }
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -21,6 +21,14 @@ if (missingEnvVars.length > 0 && process.env.NODE_ENV !== 'test') {
 const nextConfig: NextConfig = {
   /* config options here */
   reactStrictMode: false,
+  env: {
+    // Expose a browser-readable debug flag while allowing a single operational
+    // backend env var to control both server and frontend logger behavior.
+    NEXT_PUBLIC_ENABLE_DEBUG_LOGGING:
+      process.env.NEXT_PUBLIC_ENABLE_DEBUG_LOGGING ??
+      process.env.ENABLE_DEBUG_LOGGING ??
+      'false',
+  },
   turbopack: {
     resolveAlias: {
       '@': './src',


### PR DESCRIPTION
This should close #246 

don't be alarmed by the amount of files changed. most are replacing fronent console.logs with the logger 😅 

## Summary
- add structured frontend logging helpers and replace frontend console error calls
- add frontend log ingestion route to forward browser logs to server logs for CloudWatch
- add Amplify-safe origin guard for frontend log ingest endpoint
- add global frontend error listeners for uncaught errors and unhandled rejections

