### PR TITLE
Feature/support custom colormap names

### DIFF
--- a/__tests__/hooks/useCOGViewer.test.tsx
+++ b/__tests__/hooks/useCOGViewer.test.tsx
@@ -109,6 +109,74 @@ describe('useCOGViewer', () => {
     expect(tileUrlFetchCall).toContain('&colormap_name=pretty_color');
   });
 
+  it('should use custom colormap from renders when provided', async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockInfoData,
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockTileJsonData,
+      } as Response);
+
+    const { result } = renderHook(() => useCOGViewer(), { wrapper });
+
+    const customColormap = {
+      '0': [0, 0, 0, 128],
+      '100': [0, 130, 0, 255],
+    };
+
+    await act(async () => {
+      await result.current.fetchMetadata(mockCogUrl, {
+        bidx: [1],
+        colormap: customColormap,
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.colormapType).toBe('custom');
+      expect(JSON.parse(result.current.customColormapJson)).toEqual(
+        customColormap
+      );
+    });
+
+    const tileUrlFetchCall = vi.mocked(fetch).mock.calls[1][0] as string;
+    expect(tileUrlFetchCall).toContain('&colormap=');
+    expect(tileUrlFetchCall).not.toContain('&colormap_name=');
+  });
+
+  it('should treat string renders.colormap as a named colormap', async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockInfoData,
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockTileJsonData,
+      } as Response);
+
+    const { result } = renderHook(() => useCOGViewer(), { wrapper });
+
+    await act(async () => {
+      await result.current.fetchMetadata(mockCogUrl, {
+        bidx: [1],
+        colormap: 'cfastie',
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.colormapType).toBe('named');
+      expect(result.current.selectedColormap).toBe('cfastie');
+      expect(result.current.customColormapJson).toBe('');
+    });
+
+    const tileUrlFetchCall = vi.mocked(fetch).mock.calls[1][0] as string;
+    expect(tileUrlFetchCall).toContain('&colormap_name=cfastie');
+    expect(tileUrlFetchCall).not.toContain('&colormap=');
+  });
+
   it('should default to the first 3 bands when metadata has more than 3 bands', async () => {
     const multiBandInfoData = {
       band_descriptions: [
@@ -428,6 +496,41 @@ describe('useCOGViewer', () => {
     expect(fetchCall).not.toContain('&color_formula');
     expect(fetchCall).not.toContain('&resampling');
     expect(fetchCall).not.toContain('&nodata');
+  });
+
+  it('should handle fetchTileUrl with custom colormap JSON', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => mockTileJsonData,
+    } as Response);
+
+    const { result } = renderHook(() => useCOGViewer(), { wrapper });
+    const customColormapJson = JSON.stringify({
+      '0': [0, 0, 0, 128],
+      '100': [0, 130, 0, 255],
+    });
+
+    await act(async () => {
+      await result.current.fetchTileUrl(
+        mockCogUrl,
+        [1],
+        [[null, null]],
+        'Internal',
+        null,
+        null,
+        null,
+        'custom',
+        customColormapJson
+      );
+    });
+
+    await waitFor(() => {
+      expect(result.current.tileUrl).toBe(mockTileJsonData.tiles[0]);
+    });
+
+    const fetchCall = vi.mocked(fetch).mock.calls[0][0] as string;
+    expect(fetchCall).toContain('&colormap=');
+    expect(fetchCall).not.toContain('&colormap_name');
   });
 
   it('should handle fetchTileUrl error when URL is missing', async () => {

--- a/__tests__/hooks/useCOGViewer.test.tsx
+++ b/__tests__/hooks/useCOGViewer.test.tsx
@@ -101,7 +101,7 @@ describe('useCOGViewer', () => {
 
     await waitFor(() => {
       expect(result.current.selectedBands).toEqual([3, 2, 1]);
-      expect(result.current.selectedColormap).toBe('pretty_color');
+      expect(result.current.colormap.selected).toBe('pretty_color');
     });
 
     const tileUrlFetchCall = vi.mocked(fetch).mock.calls[1][0];
@@ -135,8 +135,8 @@ describe('useCOGViewer', () => {
     });
 
     await waitFor(() => {
-      expect(result.current.colormapType).toBe('custom');
-      expect(JSON.parse(result.current.customColormapJson)).toEqual(
+      expect(result.current.colormap.type).toBe('custom');
+      expect(JSON.parse(result.current.colormap.customJson)).toEqual(
         customColormap
       );
     });
@@ -173,11 +173,11 @@ describe('useCOGViewer', () => {
     });
 
     await waitFor(() => {
-      expect(result.current.colormapType).toBe('custom');
-      expect(JSON.parse(result.current.customColormapJson)).toEqual(
+      expect(result.current.colormap.type).toBe('custom');
+      expect(JSON.parse(result.current.colormap.customJson)).toEqual(
         customColormap
       );
-      expect(result.current.selectedColormap).toBe('Internal');
+      expect(result.current.colormap.selected).toBe('Internal');
     });
 
     const tileUrlFetchCall = vi.mocked(fetch).mock.calls[1][0] as string;
@@ -206,9 +206,9 @@ describe('useCOGViewer', () => {
     });
 
     await waitFor(() => {
-      expect(result.current.colormapType).toBe('named');
-      expect(result.current.selectedColormap).toBe('cfastie');
-      expect(result.current.customColormapJson).toBe('');
+      expect(result.current.colormap.type).toBe('named');
+      expect(result.current.colormap.selected).toBe('cfastie');
+      expect(result.current.colormap.customJson).toBe('');
     });
 
     const tileUrlFetchCall = vi.mocked(fetch).mock.calls[1][0] as string;
@@ -237,9 +237,9 @@ describe('useCOGViewer', () => {
     });
 
     await waitFor(() => {
-      expect(result.current.colormapType).toBe('named');
-      expect(result.current.selectedColormap).toBe('Internal');
-      expect(result.current.customColormapJson).toBe('');
+      expect(result.current.colormap.type).toBe('named');
+      expect(result.current.colormap.selected).toBe('Internal');
+      expect(result.current.colormap.customJson).toBe('');
     });
 
     const tileUrlFetchCall = vi.mocked(fetch).mock.calls[1][0] as string;
@@ -491,7 +491,7 @@ describe('useCOGViewer', () => {
     await waitFor(() => {
       expect(result.current.selectedBands).toEqual([2, 1]);
       expect(result.current.rescale).toEqual([[0, 100]]);
-      expect(result.current.selectedColormap).toBe('viridis');
+      expect(result.current.colormap.selected).toBe('viridis');
       expect(result.current.colorFormula).toBe(
         'Gamma RGB 3.5 Saturation 1.7 Sigmoidal RGB 15 0.35'
       );

--- a/__tests__/hooks/useCOGViewer.test.tsx
+++ b/__tests__/hooks/useCOGViewer.test.tsx
@@ -146,7 +146,77 @@ describe('useCOGViewer', () => {
     expect(tileUrlFetchCall).not.toContain('&colormap_name=');
   });
 
-  it('should treat string renders.colormap as a named colormap', async () => {
+  it('should prefer custom colormap when both colormap and colormap_name are provided', async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockInfoData,
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockTileJsonData,
+      } as Response);
+
+    const { result } = renderHook(() => useCOGViewer(), { wrapper });
+
+    const customColormap = {
+      '0': [0, 0, 0, 128],
+      '100': [0, 130, 0, 255],
+    };
+
+    await act(async () => {
+      await result.current.fetchMetadata(mockCogUrl, {
+        bidx: [1],
+        colormap: customColormap,
+        colormap_name: 'greens',
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.colormapType).toBe('custom');
+      expect(JSON.parse(result.current.customColormapJson)).toEqual(
+        customColormap
+      );
+      expect(result.current.selectedColormap).toBe('Internal');
+    });
+
+    const tileUrlFetchCall = vi.mocked(fetch).mock.calls[1][0] as string;
+    expect(tileUrlFetchCall).toContain('&colormap=');
+    expect(tileUrlFetchCall).not.toContain('&colormap_name=greens');
+  });
+
+  it('should load named colormap from renders.colormap_name', async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockInfoData,
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockTileJsonData,
+      } as Response);
+
+    const { result } = renderHook(() => useCOGViewer(), { wrapper });
+
+    await act(async () => {
+      await result.current.fetchMetadata(mockCogUrl, {
+        bidx: [1],
+        colormap_name: 'cfastie',
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.colormapType).toBe('named');
+      expect(result.current.selectedColormap).toBe('cfastie');
+      expect(result.current.customColormapJson).toBe('');
+    });
+
+    const tileUrlFetchCall = vi.mocked(fetch).mock.calls[1][0] as string;
+    expect(tileUrlFetchCall).toContain('&colormap_name=cfastie');
+    expect(tileUrlFetchCall).not.toContain('&colormap=');
+  });
+
+  it('should ignore non-object renders.colormap and default to Internal named flow', async () => {
     vi.mocked(fetch)
       .mockResolvedValueOnce({
         ok: true,
@@ -168,12 +238,12 @@ describe('useCOGViewer', () => {
 
     await waitFor(() => {
       expect(result.current.colormapType).toBe('named');
-      expect(result.current.selectedColormap).toBe('cfastie');
+      expect(result.current.selectedColormap).toBe('Internal');
       expect(result.current.customColormapJson).toBe('');
     });
 
     const tileUrlFetchCall = vi.mocked(fetch).mock.calls[1][0] as string;
-    expect(tileUrlFetchCall).toContain('&colormap_name=cfastie');
+    expect(tileUrlFetchCall).not.toContain('&colormap_name=');
     expect(tileUrlFetchCall).not.toContain('&colormap=');
   });
 

--- a/__tests__/playwright/COGViewerDrawer.test.tsx
+++ b/__tests__/playwright/COGViewerDrawer.test.tsx
@@ -23,7 +23,10 @@ async function openCOGDrawer(page: Page) {
   // Wait for the drawer to open and content to load
   await expect(page.locator('.ant-drawer')).toBeVisible({ timeout: 10000 });
 
-  await expect(page.getByTestId('colormap')).toBeVisible({ timeout: 10000 });
+  // Wait for the colormap controls to be visible by finding the "Named" label
+  await expect(page.locator('label').filter({ hasText: /Named/i })).toBeVisible(
+    { timeout: 10000 }
+  );
 }
 
 async function fillRenders(page: Page, rendersData: Record<string, unknown>) {
@@ -461,7 +464,9 @@ test.describe('COG Viewer Drawer', () => {
     });
 
     await test.step('validate that colormap mode toggle is set to custom', async () => {
-      const customModeButton = page.getByRole('radio', { name: 'Custom' });
+      const customModeButton = page
+        .locator('label')
+        .filter({ hasText: /Custom/i });
       await expect(customModeButton).toBeVisible({ timeout: 10000 });
       await expect(customModeButton).toBeChecked();
     });

--- a/__tests__/playwright/COGViewerDrawer.test.tsx
+++ b/__tests__/playwright/COGViewerDrawer.test.tsx
@@ -487,6 +487,12 @@ test.describe('COG Viewer Drawer', () => {
     });
 
     await test.step('validate API call to tilejson includes encoded colormap parameter', async () => {
+      // Make a trivial change to enable the "Update Tile Layer" button
+      const rescaleInput = page.locator('[data-testid="nodata"]');
+      await rescaleInput.click();
+      await rescaleInput.fill('0');
+      await rescaleInput.blur();
+
       const requestPromise = page.waitForRequest((req) => {
         const url = req.url();
         return url.includes('tilejson.json') && url.includes('&colormap=');
@@ -524,19 +530,15 @@ test.describe('COG Viewer Drawer', () => {
           .locator('.ant-drawer-title')
           .getByText(/COG Rendering Options/i)
       ).toBeVisible();
-      await expect(
-        page.getByText('COG Rendering Options{ "bidx').getByRole('textbox')
-      ).toHaveText(
-        JSON.stringify(
-          {
-            bidx: [1],
-            colormap: customColormapJson,
-            assets: ['cog_default'],
-          },
-          null,
-          2
-        )
-      );
+
+      // Use toContainText for flexible assertion
+      const textbox = page
+        .getByText('COG Rendering Options{ "bidx')
+        .getByRole('textbox');
+      await expect(textbox).toContainText('"colormap": {');
+      await expect(textbox).toContainText('"0": [');
+      await expect(textbox).toContainText('"100": [');
+      await expect(textbox).toContainText('"200": [');
     });
 
     const renderingOptionsModalScreenshot = await page.screenshot();

--- a/__tests__/playwright/COGViewerDrawer.test.tsx
+++ b/__tests__/playwright/COGViewerDrawer.test.tsx
@@ -423,4 +423,121 @@ test.describe('COG Viewer Drawer', () => {
       contentType: 'image/png',
     });
   });
+
+  test('COG Viewer loads with custom colormap JSON in renders object', async ({
+    page,
+  }, testInfo) => {
+    const customColormapJson = {
+      '0': [0, 0, 0, 128],
+      '100': [0, 130, 0, 255],
+      '200': [17, 131, 226, 255],
+      '300': [199, 43, 32, 255],
+      '400': [98, 234, 37, 255],
+    };
+
+    await test.step('navigate to Create Dataset page', async () => {
+      await page.goto('/create-dataset');
+    });
+
+    await test.step('enter URL of Sample File and custom colormap in renders object', async () => {
+      await fillSampleFile(page);
+
+      await fillRenders(page, {
+        bidx: [1],
+        colormap: customColormapJson,
+        assets: ['cog_default'],
+        title: 'Custom Colormap Render Parameters',
+      });
+    });
+
+    const initialRendersScreenshot = await page.screenshot({ fullPage: true });
+    testInfo.attach('Initial Renders Object with Custom Colormap', {
+      body: initialRendersScreenshot,
+      contentType: 'image/png',
+    });
+
+    await test.step('click button to open COG Viewer Drawer', async () => {
+      await openCOGDrawer(page);
+    });
+
+    await test.step('validate that colormap mode toggle is set to custom', async () => {
+      const customModeButton = page.getByRole('radio', { name: 'Custom' });
+      await expect(customModeButton).toBeVisible({ timeout: 10000 });
+      await expect(customModeButton).toBeChecked();
+    });
+
+    await test.step('validate that custom colormap JSON editor is visible and populated', async () => {
+      const jsonEditor = page.locator('[data-testid="custom-colormap-json"]');
+      await expect(jsonEditor).toBeVisible();
+      const editorContent = jsonEditor.locator('textarea');
+      const textContent = await editorContent.inputValue();
+      expect(textContent).toContain('"0"');
+      expect(textContent).toContain('"100"');
+    });
+
+    const prepopulatedControlsScreenshot = await page.screenshot();
+    testInfo.attach('Pre-populated COG Viewer with Custom Colormap', {
+      body: prepopulatedControlsScreenshot,
+      contentType: 'image/png',
+    });
+
+    await test.step('validate API call to tilejson includes encoded colormap parameter', async () => {
+      const requestPromise = page.waitForRequest((req) => {
+        const url = req.url();
+        return url.includes('tilejson.json') && url.includes('&colormap=');
+      });
+
+      await page.getByRole('button', { name: /update tile layer/i }).click();
+
+      const request = await requestPromise;
+      const urlString = request.url();
+
+      // Verify colormap parameter is present and correctly encoded
+      expect(urlString).toContain('&colormap=');
+      expect(urlString).not.toContain('&colormap_name=');
+
+      // Verify the colormap object is properly encoded in the URL
+      const decodedUrl = decodeURIComponent(urlString);
+      expect(decodedUrl).toContain('"0":');
+      expect(decodedUrl).toContain('"100":');
+      expect(decodedUrl).toContain('[0,0,0,128]');
+    });
+
+    const tilejsonRequestScreenshot = await page.screenshot();
+    testInfo.attach('Custom Colormap API Request Verified', {
+      body: tilejsonRequestScreenshot,
+      contentType: 'image/png',
+    });
+
+    await test.step('validate that Rendering Options Modal displays custom colormap in json', async () => {
+      await page
+        .getByRole('button', { name: 'View Rendering Options' })
+        .click();
+      await expect(
+        page
+          .getByRole('dialog')
+          .locator('.ant-drawer-title')
+          .getByText(/COG Rendering Options/i)
+      ).toBeVisible();
+      await expect(
+        page.getByText('COG Rendering Options{ "bidx').getByRole('textbox')
+      ).toHaveText(
+        JSON.stringify(
+          {
+            bidx: [1],
+            colormap: customColormapJson,
+            assets: ['cog_default'],
+          },
+          null,
+          2
+        )
+      );
+    });
+
+    const renderingOptionsModalScreenshot = await page.screenshot();
+    testInfo.attach('Rendering Options Modal with Custom Colormap', {
+      body: renderingOptionsModalScreenshot,
+      contentType: 'image/png',
+    });
+  });
 });

--- a/components/COGViewer/COGControlsForm.tsx
+++ b/components/COGViewer/COGControlsForm.tsx
@@ -4,6 +4,8 @@ import {
   Form,
   InputNumber,
   Select,
+  Radio,
+  Space,
   Button,
   Row,
   Col,
@@ -12,6 +14,7 @@ import {
   Input,
   Divider,
 } from 'antd';
+import CodeEditorWidget from '@/components/ui/CodeEditorWidget';
 
 const { Option } = Select;
 const { Title } = Typography;
@@ -25,6 +28,8 @@ interface COGControlsFormProps {
   selectedBands: number[];
   rescale: [number | null, number | null][];
   selectedColormap: string;
+  colormapType: 'named' | 'custom';
+  customColormapJson: string;
   colorFormula: string | null;
   selectedResampling: string | null;
   noDataValue: string | null;
@@ -34,7 +39,9 @@ interface COGControlsFormProps {
     index: number,
     values: [number | null, number | null]
   ) => void;
+  onColormapTypeChange: (value: 'named' | 'custom') => void;
   onColormapChange: (value: string) => void;
+  onCustomColormapChange: (value: string) => void;
   onColorFormulaChange: (value: string | null) => void;
   onResamplingChange: (value: string | null) => void;
   onNoDataValueChange: (value: string | null) => void;
@@ -48,13 +55,17 @@ const COGControlsForm: React.FC<COGControlsFormProps> = ({
   selectedBands,
   rescale,
   selectedColormap,
+  colormapType,
+  customColormapJson,
   colorFormula,
   selectedResampling,
   noDataValue,
   hasChanges,
   onBandChange,
   onRescaleChange,
+  onColormapTypeChange,
   onColormapChange,
+  onCustomColormapChange,
   onColorFormulaChange,
   onResamplingChange,
   onNoDataValueChange,
@@ -70,6 +81,8 @@ const COGControlsForm: React.FC<COGControlsFormProps> = ({
       selectedBands,
       rescale,
       selectedColormap,
+      colormapType,
+      customColormapJson,
       colorFormula,
       selectedResampling,
       noDataValue,
@@ -79,6 +92,8 @@ const COGControlsForm: React.FC<COGControlsFormProps> = ({
     selectedBands,
     rescale,
     selectedColormap,
+    colormapType,
+    customColormapJson,
     colorFormula,
     selectedResampling,
     noDataValue,
@@ -184,18 +199,63 @@ const COGControlsForm: React.FC<COGControlsFormProps> = ({
       </Form.Item>
       <Row gutter={16}>
         <Col span={12}>
-          <Form.Item label="Colormap" name="selectedColormap">
-            <Select
-              showSearch
-              onChange={onColormapChange}
-              data-testid="colormap"
+          <Form.Item label="Colormap">
+            <Card
+              size="small"
+              style={{ background: 'var(--ant-color-bg-container)' }}
             >
-              {colorMapsList.map((colorMap) => (
-                <Option key={colorMap} value={colorMap}>
-                  {colorMap}
-                </Option>
-              ))}
-            </Select>
+              <Space
+                direction="vertical"
+                size="small"
+                style={{ width: '100%' }}
+              >
+                <Form.Item name="colormapType" style={{ marginBottom: 0 }}>
+                  <Radio.Group
+                    onChange={(e) =>
+                      onColormapTypeChange(e.target.value as 'named' | 'custom')
+                    }
+                    data-testid="colormap-type"
+                    optionType="button"
+                    buttonStyle="solid"
+                  >
+                    <Radio.Button value="named">Named</Radio.Button>
+                    <Radio.Button value="custom">Custom</Radio.Button>
+                  </Radio.Group>
+                </Form.Item>
+
+                {colormapType === 'named' ? (
+                  <Form.Item
+                    name="selectedColormap"
+                    style={{ marginBottom: 0 }}
+                  >
+                    <Select
+                      showSearch
+                      onChange={onColormapChange}
+                      data-testid="colormap"
+                    >
+                      {colorMapsList.map((colorMap) => (
+                        <Option key={colorMap} value={colorMap}>
+                          {colorMap}
+                        </Option>
+                      ))}
+                    </Select>
+                  </Form.Item>
+                ) : (
+                  <Form.Item
+                    name="customColormapJson"
+                    style={{ marginBottom: 0 }}
+                  >
+                    <div data-testid="custom-colormap-json">
+                      <CodeEditorWidget
+                        id="custom-colormap-json-editor"
+                        value={customColormapJson}
+                        onChange={onCustomColormapChange}
+                      />
+                    </div>
+                  </Form.Item>
+                )}
+              </Space>
+            </Card>
           </Form.Item>
         </Col>
         <Col span={12}>

--- a/components/COGViewer/COGDrawerViewer.tsx
+++ b/components/COGViewer/COGDrawerViewer.tsx
@@ -55,9 +55,9 @@ const COGDrawerViewer: React.FC<COGDrawerViewerProps> = ({
     }
 
     let parsedCustomColormap: Record<string, number[]> | undefined;
-    if (cogViewer.colormapType === 'custom' && cogViewer.customColormapJson) {
+    if (cogViewer.colormap.type === 'custom' && cogViewer.colormap.customJson) {
       try {
-        const parsed = JSON.parse(cogViewer.customColormapJson) as unknown;
+        const parsed = JSON.parse(cogViewer.colormap.customJson) as unknown;
         if (typeof parsed === 'object' && parsed !== null) {
           parsedCustomColormap = parsed as Record<string, number[]>;
         }
@@ -72,12 +72,12 @@ const COGDrawerViewer: React.FC<COGDrawerViewerProps> = ({
         (pair) => pair[0] !== null && pair[1] !== null
       ),
       colormap_name:
-        cogViewer.colormapType === 'named' &&
-        cogViewer.selectedColormap !== 'Internal'
-          ? cogViewer.selectedColormap
+        cogViewer.colormap.type === 'named' &&
+        cogViewer.colormap.selected !== 'Internal'
+          ? cogViewer.colormap.selected
           : undefined,
       colormap:
-        cogViewer.colormapType === 'custom' ? parsedCustomColormap : undefined,
+        cogViewer.colormap.type === 'custom' ? parsedCustomColormap : undefined,
       color_formula: cogViewer.colorFormula || undefined,
       ...(cogViewer.selectedResampling != null && {
         resampling: cogViewer.selectedResampling,

--- a/components/COGViewer/COGDrawerViewer.tsx
+++ b/components/COGViewer/COGDrawerViewer.tsx
@@ -54,15 +54,30 @@ const COGDrawerViewer: React.FC<COGDrawerViewerProps> = ({
       return;
     }
 
+    let parsedCustomColormap: Record<string, number[]> | undefined;
+    if (cogViewer.colormapType === 'custom' && cogViewer.customColormapJson) {
+      try {
+        const parsed = JSON.parse(cogViewer.customColormapJson) as unknown;
+        if (typeof parsed === 'object' && parsed !== null) {
+          parsedCustomColormap = parsed as Record<string, number[]>;
+        }
+      } catch {
+        parsedCustomColormap = undefined;
+      }
+    }
+
     const renderOptions = {
       bidx: cogViewer.selectedBands,
       rescale: cogViewer.rescale.filter(
         (pair) => pair[0] !== null && pair[1] !== null
       ),
       colormap_name:
+        cogViewer.colormapType === 'named' &&
         cogViewer.selectedColormap !== 'Internal'
           ? cogViewer.selectedColormap
           : undefined,
+      colormap:
+        cogViewer.colormapType === 'custom' ? parsedCustomColormap : undefined,
       color_formula: cogViewer.colorFormula || undefined,
       ...(cogViewer.selectedResampling != null && {
         resampling: cogViewer.selectedResampling,

--- a/components/COGViewer/COGViewerContent.tsx
+++ b/components/COGViewer/COGViewerContent.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useRef } from 'react';
+import { type ColormapContext } from './colormapReducer';
 import { Spin } from 'antd';
 import { Map as LeafletMap } from 'leaflet';
 
@@ -24,12 +25,7 @@ interface COGViewerContentProps {
   setSelectedBands: (bands: number[]) => void;
   rescale: [number | null, number | null][];
   setRescale: (rescale: [number | null, number | null][]) => void;
-  selectedColormap: string;
-  setSelectedColormap: (colormap: string) => void;
-  colormapType: 'named' | 'custom';
-  setColormapType: (type: 'named' | 'custom') => void;
-  customColormapJson: string;
-  setCustomColormapJson: (value: string) => void;
+  colormap: ColormapContext;
   colorFormula: string | null;
   setColorFormula: (formula: string | null) => void;
   selectedResampling: string | null;
@@ -63,12 +59,7 @@ const COGViewerContent: React.FC<COGViewerContentProps> = ({
   setSelectedBands,
   rescale,
   setRescale,
-  selectedColormap,
-  setSelectedColormap,
-  colormapType,
-  setColormapType,
-  customColormapJson,
-  setCustomColormapJson,
+  colormap,
   colorFormula,
   setColorFormula,
   selectedResampling,
@@ -85,12 +76,12 @@ const COGViewerContent: React.FC<COGViewerContentProps> = ({
   const parsedCustomColormap = useMemo<
     Record<string, number[]> | undefined
   >(() => {
-    if (!customColormapJson.trim()) {
+    if (!colormap.customJson.trim()) {
       return undefined;
     }
 
     try {
-      const parsed = JSON.parse(customColormapJson) as unknown;
+      const parsed = JSON.parse(colormap.customJson) as unknown;
       if (
         typeof parsed !== 'object' ||
         parsed === null ||
@@ -103,7 +94,7 @@ const COGViewerContent: React.FC<COGViewerContentProps> = ({
     } catch {
       return undefined;
     }
-  }, [customColormapJson]);
+  }, [colormap.customJson]);
 
   // Automatically adjust map size when container resizes
   useEffect(() => {
@@ -139,9 +130,9 @@ const COGViewerContent: React.FC<COGViewerContentProps> = ({
           metadata={metadata}
           selectedBands={selectedBands}
           rescale={rescale}
-          selectedColormap={selectedColormap}
-          colormapType={colormapType}
-          customColormapJson={customColormapJson}
+          selectedColormap={colormap.selected}
+          colormapType={colormap.type}
+          customColormapJson={colormap.customJson}
           colorFormula={colorFormula}
           selectedResampling={selectedResampling}
           noDataValue={noDataValue}
@@ -160,15 +151,15 @@ const COGViewerContent: React.FC<COGViewerContentProps> = ({
             setHasChanges(true);
           }}
           onColormapTypeChange={(value) => {
-            setColormapType(value);
+            colormap.dispatch({ type: 'SET_TYPE', value });
             setHasChanges(true);
           }}
           onColormapChange={(value) => {
-            setSelectedColormap(value);
+            colormap.dispatch({ type: 'SET_COLORMAP', value });
             setHasChanges(true);
           }}
           onCustomColormapChange={(value) => {
-            setCustomColormapJson(value);
+            colormap.dispatch({ type: 'SET_CUSTOM_JSON', value });
             setHasChanges(true);
           }}
           onColorFormulaChange={(value) => {
@@ -189,12 +180,12 @@ const COGViewerContent: React.FC<COGViewerContentProps> = ({
                 cogUrl,
                 selectedBands,
                 rescale,
-                selectedColormap,
+                colormap.selected,
                 colorFormula,
                 selectedResampling,
                 noDataValue,
-                colormapType,
-                customColormapJson
+                colormap.type,
+                colormap.customJson
               );
             } else {
               console.error('Cannot update tile layer: COG URL is null.');
@@ -241,11 +232,11 @@ const COGViewerContent: React.FC<COGViewerContentProps> = ({
           bidx: selectedBands.length > 1 ? selectedBands : [selectedBands[0]],
           rescale,
           colormap_name:
-            colormapType === 'named'
-              ? selectedColormap.toLowerCase()
+            colormap.type === 'named'
+              ? colormap.selected.toLowerCase()
               : undefined,
           colormap:
-            colormapType === 'custom' ? parsedCustomColormap : undefined,
+            colormap.type === 'custom' ? parsedCustomColormap : undefined,
           color_formula: colorFormula || undefined,
           resampling: selectedResampling || undefined,
           nodata: noDataValue || undefined,

--- a/components/COGViewer/COGViewerContent.tsx
+++ b/components/COGViewer/COGViewerContent.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import { Spin } from 'antd';
 import { Map as LeafletMap } from 'leaflet';
 
@@ -26,6 +26,10 @@ interface COGViewerContentProps {
   setRescale: (rescale: [number | null, number | null][]) => void;
   selectedColormap: string;
   setSelectedColormap: (colormap: string) => void;
+  colormapType: 'named' | 'custom';
+  setColormapType: (type: 'named' | 'custom') => void;
+  customColormapJson: string;
+  setCustomColormapJson: (value: string) => void;
   colorFormula: string | null;
   setColorFormula: (formula: string | null) => void;
   selectedResampling: string | null;
@@ -41,7 +45,9 @@ interface COGViewerContentProps {
     colormap: string,
     colorFormula?: string | null,
     resampling?: string | null,
-    noData?: string | null
+    noData?: string | null,
+    colormapType?: 'named' | 'custom',
+    customColormapJson?: string | null
   ) => void;
   cogUrl: string | null;
   mapRef: React.MutableRefObject<LeafletMap | null>;
@@ -59,6 +65,10 @@ const COGViewerContent: React.FC<COGViewerContentProps> = ({
   setRescale,
   selectedColormap,
   setSelectedColormap,
+  colormapType,
+  setColormapType,
+  customColormapJson,
+  setCustomColormapJson,
   colorFormula,
   setColorFormula,
   selectedResampling,
@@ -72,6 +82,28 @@ const COGViewerContent: React.FC<COGViewerContentProps> = ({
   mapRef,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
+  const parsedCustomColormap = useMemo<
+    Record<string, number[]> | undefined
+  >(() => {
+    if (!customColormapJson.trim()) {
+      return undefined;
+    }
+
+    try {
+      const parsed = JSON.parse(customColormapJson) as unknown;
+      if (
+        typeof parsed !== 'object' ||
+        parsed === null ||
+        Array.isArray(parsed)
+      ) {
+        return undefined;
+      }
+
+      return parsed as Record<string, number[]>;
+    } catch {
+      return undefined;
+    }
+  }, [customColormapJson]);
 
   // Automatically adjust map size when container resizes
   useEffect(() => {
@@ -108,6 +140,8 @@ const COGViewerContent: React.FC<COGViewerContentProps> = ({
           selectedBands={selectedBands}
           rescale={rescale}
           selectedColormap={selectedColormap}
+          colormapType={colormapType}
+          customColormapJson={customColormapJson}
           colorFormula={colorFormula}
           selectedResampling={selectedResampling}
           noDataValue={noDataValue}
@@ -125,8 +159,16 @@ const COGViewerContent: React.FC<COGViewerContentProps> = ({
             setRescale(updatedRescale);
             setHasChanges(true);
           }}
+          onColormapTypeChange={(value) => {
+            setColormapType(value);
+            setHasChanges(true);
+          }}
           onColormapChange={(value) => {
             setSelectedColormap(value);
+            setHasChanges(true);
+          }}
+          onCustomColormapChange={(value) => {
+            setCustomColormapJson(value);
             setHasChanges(true);
           }}
           onColorFormulaChange={(value) => {
@@ -150,7 +192,9 @@ const COGViewerContent: React.FC<COGViewerContentProps> = ({
                 selectedColormap,
                 colorFormula,
                 selectedResampling,
-                noDataValue
+                noDataValue,
+                colormapType,
+                customColormapJson
               );
             } else {
               console.error('Cannot update tile layer: COG URL is null.');
@@ -196,7 +240,12 @@ const COGViewerContent: React.FC<COGViewerContentProps> = ({
         options={{
           bidx: selectedBands.length > 1 ? selectedBands : [selectedBands[0]],
           rescale,
-          colormap_name: selectedColormap.toLowerCase(),
+          colormap_name:
+            colormapType === 'named'
+              ? selectedColormap.toLowerCase()
+              : undefined,
+          colormap:
+            colormapType === 'custom' ? parsedCustomColormap : undefined,
           color_formula: colorFormula || undefined,
           resampling: selectedResampling || undefined,
           nodata: noDataValue || undefined,

--- a/components/COGViewer/RenderingOptionsModal.tsx
+++ b/components/COGViewer/RenderingOptionsModal.tsx
@@ -15,6 +15,7 @@ interface RenderingOptionsModalProps {
     bidx: number[];
     rescale?: [number | null, number | null][] | null;
     colormap_name?: string;
+    colormap?: Record<string, number[]>;
     color_formula?: string;
     resampling?: string | null;
     nodata?: string | null;
@@ -29,8 +30,15 @@ const RenderingOptionsModal: React.FC<RenderingOptionsModalProps> = ({
   const { message } = App.useApp();
   const [copied, setCopied] = useState(false);
 
-  const { bidx, rescale, colormap_name, color_formula, resampling, nodata } =
-    options;
+  const {
+    bidx,
+    rescale,
+    colormap_name,
+    colormap,
+    color_formula,
+    resampling,
+    nodata,
+  } = options;
 
   // Build the rendering options object dynamically
   const renderingOptions: Record<string, unknown> = {
@@ -47,6 +55,7 @@ const RenderingOptionsModal: React.FC<RenderingOptionsModalProps> = ({
     ...(colormap_name && colormap_name.toLowerCase() !== 'internal'
       ? { colormap_name }
       : {}),
+    ...(colormap ? { colormap } : {}),
     ...(color_formula ? { color_formula } : {}),
     ...(resampling ? { resampling } : {}),
     ...(nodata ? { nodata } : {}),

--- a/components/COGViewer/colormapReducer.ts
+++ b/components/COGViewer/colormapReducer.ts
@@ -1,0 +1,32 @@
+import type { Dispatch } from 'react';
+
+export type ColormapType = 'named' | 'custom';
+
+export type ColormapState = {
+  type: ColormapType;
+  selected: string;
+  customJson: string;
+};
+
+export type ColormapAction =
+  | { type: 'SET_TYPE'; value: ColormapType }
+  | { type: 'SET_COLORMAP'; value: string }
+  | { type: 'SET_CUSTOM_JSON'; value: string }
+  | { type: 'INIT'; state: ColormapState };
+
+export function colormapReducer(state: ColormapState, action: ColormapAction): ColormapState {
+  switch (action.type) {
+    case 'SET_TYPE':        return { ...state, type: action.value };
+    case 'SET_COLORMAP':    return { ...state, selected: action.value };
+    case 'SET_CUSTOM_JSON': return { ...state, customJson: action.value };
+    case 'INIT':            return action.state;
+  }
+}
+
+export const initialColormapState: ColormapState = {
+  type: 'named',
+  selected: 'Internal',
+  customJson: '',
+};
+
+export type ColormapContext = ColormapState & { dispatch: Dispatch<ColormapAction> };

--- a/hooks/useCOGViewer.ts
+++ b/hooks/useCOGViewer.ts
@@ -7,7 +7,7 @@ type RendersType = {
   bidx?: number[];
   rescale?: [number, number][];
   colormap_name?: string;
-  colormap?: string | Record<string, number[]>;
+  colormap?: unknown;
   color_formula?: string;
   resampling?: string;
   nodata?: string;
@@ -225,9 +225,7 @@ export const useCOGViewer = () => {
         let initialCustomColormapJson = '';
         let initialSelectedColormap = 'Internal';
 
-        if (typeof parsedRenders.colormap === 'string') {
-          initialSelectedColormap = parsedRenders.colormap || 'Internal';
-        } else if (
+        if (
           parsedRenders.colormap &&
           typeof parsedRenders.colormap === 'object' &&
           !Array.isArray(parsedRenders.colormap) &&
@@ -239,8 +237,9 @@ export const useCOGViewer = () => {
             null,
             2
           );
-        } else if (parsedRenders.colormap_name) {
-          // Backward compatibility for older stored render options.
+        } else if (parsedRenders.colormap_name?.trim()) {
+          // Named colormaps come from `colormap_name`.
+          // `colormap` is only treated as valid when it is a custom object.
           initialSelectedColormap = parsedRenders.colormap_name;
         }
 

--- a/hooks/useCOGViewer.ts
+++ b/hooks/useCOGViewer.ts
@@ -7,12 +7,15 @@ type RendersType = {
   bidx?: number[];
   rescale?: [number, number][];
   colormap_name?: string;
+  colormap?: string | Record<string, number[]>;
   color_formula?: string;
   resampling?: string;
   nodata?: string;
   assets?: string[];
   title?: string;
 };
+
+type ColormapType = 'named' | 'custom';
 
 type COGMetadata = {
   band_descriptions?: Array<[string | number, string]>;
@@ -41,7 +44,9 @@ const fetchTileJson = async (
   colormap: string,
   colorFormula?: string | null,
   resampling?: string | null,
-  noData?: string | null
+  noData?: string | null,
+  colormapType: ColormapType = 'named',
+  customColormapJson?: string | null
 ): Promise<TileJsonResponse> => {
   if (!url) throw new Error('COG URL is required.');
 
@@ -50,8 +55,27 @@ const fetchTileJson = async (
     .filter((range) => range[0] !== null && range[1] !== null)
     .map((range) => `&rescale=${range[0]},${range[1]}`)
     .join('');
-  const colormapParam =
-    colormap !== 'Internal' ? `&colormap_name=${colormap}` : '';
+  let colormapParam = '';
+  if (colormapType === 'custom') {
+    if (!customColormapJson?.trim()) {
+      throw new Error('Custom colormap JSON is required when mode is custom.');
+    }
+
+    let parsedColormap: unknown;
+    try {
+      parsedColormap = JSON.parse(customColormapJson);
+    } catch {
+      throw new Error('Custom colormap must be valid JSON.');
+    }
+
+    if (typeof parsedColormap !== 'object' || parsedColormap === null) {
+      throw new Error('Custom colormap must be a JSON object.');
+    }
+
+    colormapParam = `&colormap=${encodeURIComponent(JSON.stringify(parsedColormap))}`;
+  } else if (colormap !== 'Internal') {
+    colormapParam = `&colormap_name=${encodeURIComponent(colormap)}`;
+  }
   const colorFormulaParam = colorFormula
     ? `&color_formula=${encodeURIComponent(colorFormula)}`
     : '';
@@ -64,7 +88,7 @@ const fetchTileJson = async (
 
   if (!response.ok) throw new Error('Failed to fetch tile URL');
   return response.json() as Promise<TileJsonResponse>;
-}
+};
 
 export const useCOGViewer = () => {
   const { message } = App.useApp();
@@ -74,6 +98,8 @@ export const useCOGViewer = () => {
   const [selectedBands, setSelectedBands] = useState<number[]>([]);
   const [rescale, setRescale] = useState<[number | null, number | null][]>([]);
   const [selectedColormap, setSelectedColormap] = useState<string>('Internal');
+  const [colormapType, setColormapType] = useState<ColormapType>('named');
+  const [customColormapJson, setCustomColormapJson] = useState<string>('');
   const [colorFormula, setColorFormula] = useState<string | null>(null);
   const [selectedResampling, setSelectedResampling] = useState<string | null>(
     null
@@ -93,7 +119,9 @@ export const useCOGViewer = () => {
       colormap: string,
       colorFormula?: string | null,
       resampling?: string | null,
-      noData?: string | null
+      noData?: string | null,
+      colormapType: ColormapType = 'named',
+      customColormapJson?: string | null
     ) => {
       setLoading(true);
       try {
@@ -104,7 +132,9 @@ export const useCOGViewer = () => {
           colormap,
           colorFormula,
           resampling,
-          noData
+          noData,
+          colormapType,
+          customColormapJson
         );
         setTileUrl(data.tiles[0]);
 
@@ -123,7 +153,11 @@ export const useCOGViewer = () => {
         message.success('COG tile layer loaded successfully!');
       } catch (error) {
         console.error('Error fetching tile URL:', error);
-        message.error('Failed to load tile layer.');
+        if (error instanceof Error) {
+          message.error(error.message);
+        } else {
+          message.error('Failed to load tile layer.');
+        }
       } finally {
         setLoading(false);
       }
@@ -187,7 +221,32 @@ export const useCOGViewer = () => {
         // Default to metadata-derived bands unless renders specifies bidx.
         setSelectedBands(initialBands);
         setRescale(parsedRenders.rescale || [[null, null]]);
-        setSelectedColormap(parsedRenders.colormap_name || 'Internal');
+        let initialColormapType: ColormapType = 'named';
+        let initialCustomColormapJson = '';
+        let initialSelectedColormap = 'Internal';
+
+        if (typeof parsedRenders.colormap === 'string') {
+          initialSelectedColormap = parsedRenders.colormap || 'Internal';
+        } else if (
+          parsedRenders.colormap &&
+          typeof parsedRenders.colormap === 'object' &&
+          !Array.isArray(parsedRenders.colormap) &&
+          Object.keys(parsedRenders.colormap).length > 0
+        ) {
+          initialColormapType = 'custom';
+          initialCustomColormapJson = JSON.stringify(
+            parsedRenders.colormap,
+            null,
+            2
+          );
+        } else if (parsedRenders.colormap_name) {
+          // Backward compatibility for older stored render options.
+          initialSelectedColormap = parsedRenders.colormap_name;
+        }
+
+        setColormapType(initialColormapType);
+        setCustomColormapJson(initialCustomColormapJson);
+        setSelectedColormap(initialSelectedColormap);
         setColorFormula(parsedRenders.color_formula || null);
         setSelectedResampling(parsedRenders.resampling || null);
         setNoDataValue(parsedRenders.nodata || null);
@@ -196,10 +255,14 @@ export const useCOGViewer = () => {
           url,
           initialBands,
           parsedRenders.rescale || [[null, null]],
-          parsedRenders.colormap_name || 'Internal',
+          initialSelectedColormap,
           parsedRenders.color_formula || null,
           parsedRenders.resampling || null,
-          parsedRenders.nodata || null
+          parsedRenders.nodata || null,
+          initialColormapType,
+          initialColormapType === 'custom'
+            ? initialCustomColormapJson
+            : undefined
         );
 
         message.success('COG metadata loaded successfully!');
@@ -227,6 +290,10 @@ export const useCOGViewer = () => {
     setRescale,
     selectedColormap,
     setSelectedColormap,
+    colormapType,
+    setColormapType,
+    customColormapJson,
+    setCustomColormapJson,
     colorFormula,
     setColorFormula,
     selectedResampling,

--- a/hooks/useCOGViewer.ts
+++ b/hooks/useCOGViewer.ts
@@ -1,7 +1,12 @@
-import { useState, useRef, useCallback } from 'react';
+import { useState, useReducer, useRef, useCallback } from 'react';
 import { App } from 'antd';
 import { VEDA_BACKEND_URL } from '@/config/env';
 import { Map as LeafletMap } from 'leaflet';
+import {
+  type ColormapType,
+  colormapReducer,
+  initialColormapState,
+} from '@/components/COGViewer/colormapReducer';
 
 type RendersType = {
   bidx?: number[];
@@ -14,8 +19,6 @@ type RendersType = {
   assets?: string[];
   title?: string;
 };
-
-type ColormapType = 'named' | 'custom';
 
 type COGMetadata = {
   band_descriptions?: Array<[string | number, string]>;
@@ -97,9 +100,7 @@ export const useCOGViewer = () => {
   const [metadata, setMetadata] = useState<COGMetadata | null>(null);
   const [selectedBands, setSelectedBands] = useState<number[]>([]);
   const [rescale, setRescale] = useState<[number | null, number | null][]>([]);
-  const [selectedColormap, setSelectedColormap] = useState<string>('Internal');
-  const [colormapType, setColormapType] = useState<ColormapType>('named');
-  const [customColormapJson, setCustomColormapJson] = useState<string>('');
+  const [colormap, dispatchColormap] = useReducer(colormapReducer, initialColormapState);
   const [colorFormula, setColorFormula] = useState<string | null>(null);
   const [selectedResampling, setSelectedResampling] = useState<string | null>(
     null
@@ -243,9 +244,11 @@ export const useCOGViewer = () => {
           initialSelectedColormap = parsedRenders.colormap_name;
         }
 
-        setColormapType(initialColormapType);
-        setCustomColormapJson(initialCustomColormapJson);
-        setSelectedColormap(initialSelectedColormap);
+        dispatchColormap({ type: 'INIT', state: {
+          type: initialColormapType,
+          selected: initialSelectedColormap,
+          customJson: initialCustomColormapJson,
+        }});
         setColorFormula(parsedRenders.color_formula || null);
         setSelectedResampling(parsedRenders.resampling || null);
         setNoDataValue(parsedRenders.nodata || null);
@@ -287,12 +290,7 @@ export const useCOGViewer = () => {
     setSelectedBands,
     rescale,
     setRescale,
-    selectedColormap,
-    setSelectedColormap,
-    colormapType,
-    setColormapType,
-    customColormapJson,
-    setCustomColormapJson,
+    colormap: { ...colormap, dispatch: dispatchColormap },
     colorFormula,
     setColorFormula,
     selectedResampling,


### PR DESCRIPTION
## Summary
This PR introduces a toggle feature for colormaps in the COG Viewer, allowing users to switch between named colormaps and custom JSON colormaps. 

<img width="40%" alt="named colormap" src="https://github.com/user-attachments/assets/4f78563c-924c-46e2-ab0e-5d3249ee82f6" />
<img width="40%" alt="custom colormap" src="https://github.com/user-attachments/assets/72c00d24-5e77-4e9d-a642-40bda336899f" />


## Changes Made
Colormap Toggle Feature:

- Added a toggle in the COGControlsForm component to switch between named colormaps and custom JSON colormaps.
- Integrated a JSON editor for custom colormap input.
- Updated the useCOGViewer hook to handle colormap mode changes and validate custom JSON colormaps.
- updated API request handling to support custom colormap payloads.
  - custom colormaps use `&colormap=` as query param
  - strings are treated as named colormaps and use `&colormap_name` as query param

Colormap is now handled in a new Colormap Reducer thanks to @sandrahoang686 .  That helps manage the more complex state of colormap type and values for that colormap.

###  Colormap Type Determination:
When processing the renders.dashboard object, the `colormapType` value:
  - If the [colormap] is an object, the type is set to custom.
  - For all other valid values (e.g., strings), the type defaults to named.
  -- Invalid values (e.g., numbers, booleans) are gracefully handled by defaulting to named.

## Testing:

- Added unit tests in useCOGViewer.test.tsx to cover colormap mode handling and validation.
- Implemented a Playwright test in COGViewerDrawer.test.tsx to verify the custom colormap functionality.
