### PR TITLE
Feat/add renders to collections

### DIFF
--- a/FormSchemas/collections/collectionSchema.json
+++ b/FormSchemas/collections/collectionSchema.json
@@ -234,6 +234,23 @@
       "type": "string",
       "format": "duration",
       "title": "Time Interval"
+    },
+    "renders": {
+      "title": "Renders",
+      "type": "object",
+      "properties": {
+        "dashboard": {
+          "type": ["string", "object"],
+          "title": "Dashboard"
+        }
+      },
+      "default": {
+        "dashboard": {}
+      },
+      "additionalProperties": {
+        "type": ["string", "object"],
+        "title": "Render"
+      }
     }
   }
 }

--- a/FormSchemas/collections/uischema.json
+++ b/FormSchemas/collections/uischema.json
@@ -20,7 +20,8 @@
       "extent": 24
     },
     {
-      "links": 24
+      "renders": 12,
+      "links": 12
     },
     {
       "summaries": 24
@@ -74,5 +75,20 @@
       "description": "This describes the STAC collection.",
       "rows": 8
     }
+  },
+  "renders": {
+    "dashboard": {
+      "ui:widget": "renders.dashboard",
+      "ui:options": {
+        "rows": 12
+      }
+    },
+    "additionalProperties": {
+      "ui:widget": "renders.dashboard",
+      "ui:options": {
+        "rows": 12
+      }
+    },
+    "ui:classNames": "renders"
   }
 }

--- a/components/ingestion/CollectionIngestionForm.tsx
+++ b/components/ingestion/CollectionIngestionForm.tsx
@@ -39,6 +39,7 @@ import BboxField from '@/utils/BboxField';
 import IntervalField from '@/utils/IntervalField';
 import AssetField from '@/components/rjsf-components/AssetsField';
 import CodeEditorWidget from '@/components/ui/CodeEditorWidget';
+import { RendersDashboardWidget } from '@/components/rjsf-components/RendersDashboardWidget';
 import SummariesManager from '@/components/rjsf-components/SummariesManager';
 
 import staticBaseSchema from '@/FormSchemas/collections/collectionSchema.json';
@@ -104,6 +105,10 @@ function CollectionIngestionForm({
     : { ...uiSchema, ...lockedFormFields };
 
   const formScopedData = formData;
+
+  const widgets = {
+    'renders.dashboard': RendersDashboardWidget,
+  };
 
   const prevFormDataRef = useRef(formData);
   useEffect(() => {
@@ -292,6 +297,7 @@ function CollectionIngestionForm({
                   fields={customFields}
                   formData={rjsfFormData}
                   onChange={onRJSFDataChanged}
+                  widgets={widgets}
                   tagName="div"
                 >
                   <></>

--- a/components/rjsf-components/RendersDashboardWidget.tsx
+++ b/components/rjsf-components/RendersDashboardWidget.tsx
@@ -44,6 +44,8 @@ export const RendersDashboardWidget = ({
     | FormContextWithSampleFiles
     | undefined;
   const isDashboardField = id.endsWith('_dashboard');
+  const hasSampleFiles =
+    context?.formData?.sample_files && context.formData.sample_files.length > 0;
 
   const handleOpenCOGDrawer = () => {
     const sampleUrl = context?.formData?.sample_files?.[0];
@@ -75,7 +77,7 @@ export const RendersDashboardWidget = ({
         readOnly={!!(readonly || disabled)}
       />
 
-      {isDashboardField && (
+      {isDashboardField && hasSampleFiles && (
         <>
           {errorMessage && (
             <Alert


### PR DESCRIPTION
This allows the create/edit collection flow to handle renders objects. Functionality is similar to the dataset implementation: 
 - renders.dashboard is shown by default
 - optional additional renders objects can be added
 - the entries are optional

The examples collections didn't include a sample_file.  Assuming this is the case, then the "Generate Renders Options button to open a preview of the renders with the sample file becomes unusable.  To handle this, I added a check in the widget to hide the button if no sample_files are in the form.

<img width="1744" height="971" alt="Screenshot 2026-05-15 at 9 15 14 AM" src="https://github.com/user-attachments/assets/321551a4-586d-4ba1-a203-9eb21760d2d4" />

This should eliminate the need for #272 . The CodeEditorWidgets need that stringified value for the renders objects.  It could possibly removed and just use a text area, but you lose the syntaxt highlighting.