### PR TITLE
Colormap Reducer to combine to a state slice

### DIFF
--- a/__tests__/hooks/useCOGViewer.test.tsx
+++ b/__tests__/hooks/useCOGViewer.test.tsx
@@ -101,7 +101,7 @@ describe('useCOGViewer', () => {
 
     await waitFor(() => {
       expect(result.current.selectedBands).toEqual([3, 2, 1]);
-      expect(result.current.selectedColormap).toBe('pretty_color');
+      expect(result.current.colormap.selected).toBe('pretty_color');
     });
 
     const tileUrlFetchCall = vi.mocked(fetch).mock.calls[1][0];
@@ -135,8 +135,8 @@ describe('useCOGViewer', () => {
     });
 
     await waitFor(() => {
-      expect(result.current.colormapType).toBe('custom');
-      expect(JSON.parse(result.current.customColormapJson)).toEqual(
+      expect(result.current.colormap.type).toBe('custom');
+      expect(JSON.parse(result.current.colormap.customJson)).toEqual(
         customColormap
       );
     });
@@ -173,11 +173,11 @@ describe('useCOGViewer', () => {
     });
 
     await waitFor(() => {
-      expect(result.current.colormapType).toBe('custom');
-      expect(JSON.parse(result.current.customColormapJson)).toEqual(
+      expect(result.current.colormap.type).toBe('custom');
+      expect(JSON.parse(result.current.colormap.customJson)).toEqual(
         customColormap
       );
-      expect(result.current.selectedColormap).toBe('Internal');
+      expect(result.current.colormap.selected).toBe('Internal');
     });
 
     const tileUrlFetchCall = vi.mocked(fetch).mock.calls[1][0] as string;
@@ -206,9 +206,9 @@ describe('useCOGViewer', () => {
     });
 
     await waitFor(() => {
-      expect(result.current.colormapType).toBe('named');
-      expect(result.current.selectedColormap).toBe('cfastie');
-      expect(result.current.customColormapJson).toBe('');
+      expect(result.current.colormap.type).toBe('named');
+      expect(result.current.colormap.selected).toBe('cfastie');
+      expect(result.current.colormap.customJson).toBe('');
     });
 
     const tileUrlFetchCall = vi.mocked(fetch).mock.calls[1][0] as string;
@@ -237,9 +237,9 @@ describe('useCOGViewer', () => {
     });
 
     await waitFor(() => {
-      expect(result.current.colormapType).toBe('named');
-      expect(result.current.selectedColormap).toBe('Internal');
-      expect(result.current.customColormapJson).toBe('');
+      expect(result.current.colormap.type).toBe('named');
+      expect(result.current.colormap.selected).toBe('Internal');
+      expect(result.current.colormap.customJson).toBe('');
     });
 
     const tileUrlFetchCall = vi.mocked(fetch).mock.calls[1][0] as string;
@@ -491,7 +491,7 @@ describe('useCOGViewer', () => {
     await waitFor(() => {
       expect(result.current.selectedBands).toEqual([2, 1]);
       expect(result.current.rescale).toEqual([[0, 100]]);
-      expect(result.current.selectedColormap).toBe('viridis');
+      expect(result.current.colormap.selected).toBe('viridis');
       expect(result.current.colorFormula).toBe(
         'Gamma RGB 3.5 Saturation 1.7 Sigmoidal RGB 15 0.35'
       );

--- a/components/COGViewer/COGDrawerViewer.tsx
+++ b/components/COGViewer/COGDrawerViewer.tsx
@@ -55,9 +55,9 @@ const COGDrawerViewer: React.FC<COGDrawerViewerProps> = ({
     }
 
     let parsedCustomColormap: Record<string, number[]> | undefined;
-    if (cogViewer.colormapType === 'custom' && cogViewer.customColormapJson) {
+    if (cogViewer.colormap.type === 'custom' && cogViewer.colormap.customJson) {
       try {
-        const parsed = JSON.parse(cogViewer.customColormapJson) as unknown;
+        const parsed = JSON.parse(cogViewer.colormap.customJson) as unknown;
         if (typeof parsed === 'object' && parsed !== null) {
           parsedCustomColormap = parsed as Record<string, number[]>;
         }
@@ -72,12 +72,12 @@ const COGDrawerViewer: React.FC<COGDrawerViewerProps> = ({
         (pair) => pair[0] !== null && pair[1] !== null
       ),
       colormap_name:
-        cogViewer.colormapType === 'named' &&
-        cogViewer.selectedColormap !== 'Internal'
-          ? cogViewer.selectedColormap
+        cogViewer.colormap.type === 'named' &&
+        cogViewer.colormap.selected !== 'Internal'
+          ? cogViewer.colormap.selected
           : undefined,
       colormap:
-        cogViewer.colormapType === 'custom' ? parsedCustomColormap : undefined,
+        cogViewer.colormap.type === 'custom' ? parsedCustomColormap : undefined,
       color_formula: cogViewer.colorFormula || undefined,
       ...(cogViewer.selectedResampling != null && {
         resampling: cogViewer.selectedResampling,

--- a/components/COGViewer/COGViewerContent.tsx
+++ b/components/COGViewer/COGViewerContent.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useRef } from 'react';
+import { type ColormapContext } from './colormapReducer';
 import { Spin } from 'antd';
 import { Map as LeafletMap } from 'leaflet';
 
@@ -24,12 +25,7 @@ interface COGViewerContentProps {
   setSelectedBands: (bands: number[]) => void;
   rescale: [number | null, number | null][];
   setRescale: (rescale: [number | null, number | null][]) => void;
-  selectedColormap: string;
-  setSelectedColormap: (colormap: string) => void;
-  colormapType: 'named' | 'custom';
-  setColormapType: (type: 'named' | 'custom') => void;
-  customColormapJson: string;
-  setCustomColormapJson: (value: string) => void;
+  colormap: ColormapContext;
   colorFormula: string | null;
   setColorFormula: (formula: string | null) => void;
   selectedResampling: string | null;
@@ -63,12 +59,7 @@ const COGViewerContent: React.FC<COGViewerContentProps> = ({
   setSelectedBands,
   rescale,
   setRescale,
-  selectedColormap,
-  setSelectedColormap,
-  colormapType,
-  setColormapType,
-  customColormapJson,
-  setCustomColormapJson,
+  colormap,
   colorFormula,
   setColorFormula,
   selectedResampling,
@@ -85,12 +76,12 @@ const COGViewerContent: React.FC<COGViewerContentProps> = ({
   const parsedCustomColormap = useMemo<
     Record<string, number[]> | undefined
   >(() => {
-    if (!customColormapJson.trim()) {
+    if (!colormap.customJson.trim()) {
       return undefined;
     }
 
     try {
-      const parsed = JSON.parse(customColormapJson) as unknown;
+      const parsed = JSON.parse(colormap.customJson) as unknown;
       if (
         typeof parsed !== 'object' ||
         parsed === null ||
@@ -103,7 +94,7 @@ const COGViewerContent: React.FC<COGViewerContentProps> = ({
     } catch {
       return undefined;
     }
-  }, [customColormapJson]);
+  }, [colormap.customJson]);
 
   // Automatically adjust map size when container resizes
   useEffect(() => {
@@ -139,9 +130,9 @@ const COGViewerContent: React.FC<COGViewerContentProps> = ({
           metadata={metadata}
           selectedBands={selectedBands}
           rescale={rescale}
-          selectedColormap={selectedColormap}
-          colormapType={colormapType}
-          customColormapJson={customColormapJson}
+          selectedColormap={colormap.selected}
+          colormapType={colormap.type}
+          customColormapJson={colormap.customJson}
           colorFormula={colorFormula}
           selectedResampling={selectedResampling}
           noDataValue={noDataValue}
@@ -160,15 +151,15 @@ const COGViewerContent: React.FC<COGViewerContentProps> = ({
             setHasChanges(true);
           }}
           onColormapTypeChange={(value) => {
-            setColormapType(value);
+            colormap.dispatch({ type: 'SET_TYPE', value });
             setHasChanges(true);
           }}
           onColormapChange={(value) => {
-            setSelectedColormap(value);
+            colormap.dispatch({ type: 'SET_COLORMAP', value });
             setHasChanges(true);
           }}
           onCustomColormapChange={(value) => {
-            setCustomColormapJson(value);
+            colormap.dispatch({ type: 'SET_CUSTOM_JSON', value });
             setHasChanges(true);
           }}
           onColorFormulaChange={(value) => {
@@ -189,12 +180,12 @@ const COGViewerContent: React.FC<COGViewerContentProps> = ({
                 cogUrl,
                 selectedBands,
                 rescale,
-                selectedColormap,
+                colormap.selected,
                 colorFormula,
                 selectedResampling,
                 noDataValue,
-                colormapType,
-                customColormapJson
+                colormap.type,
+                colormap.customJson
               );
             } else {
               console.error('Cannot update tile layer: COG URL is null.');
@@ -241,11 +232,11 @@ const COGViewerContent: React.FC<COGViewerContentProps> = ({
           bidx: selectedBands.length > 1 ? selectedBands : [selectedBands[0]],
           rescale,
           colormap_name:
-            colormapType === 'named'
-              ? selectedColormap.toLowerCase()
+            colormap.type === 'named'
+              ? colormap.selected.toLowerCase()
               : undefined,
           colormap:
-            colormapType === 'custom' ? parsedCustomColormap : undefined,
+            colormap.type === 'custom' ? parsedCustomColormap : undefined,
           color_formula: colorFormula || undefined,
           resampling: selectedResampling || undefined,
           nodata: noDataValue || undefined,

--- a/components/COGViewer/colormapReducer.ts
+++ b/components/COGViewer/colormapReducer.ts
@@ -1,0 +1,32 @@
+import type { Dispatch } from 'react';
+
+export type ColormapType = 'named' | 'custom';
+
+export type ColormapState = {
+  type: ColormapType;
+  selected: string;
+  customJson: string;
+};
+
+export type ColormapAction =
+  | { type: 'SET_TYPE'; value: ColormapType }
+  | { type: 'SET_COLORMAP'; value: string }
+  | { type: 'SET_CUSTOM_JSON'; value: string }
+  | { type: 'INIT'; state: ColormapState };
+
+export function colormapReducer(state: ColormapState, action: ColormapAction): ColormapState {
+  switch (action.type) {
+    case 'SET_TYPE':        return { ...state, type: action.value };
+    case 'SET_COLORMAP':    return { ...state, selected: action.value };
+    case 'SET_CUSTOM_JSON': return { ...state, customJson: action.value };
+    case 'INIT':            return action.state;
+  }
+}
+
+export const initialColormapState: ColormapState = {
+  type: 'named',
+  selected: 'Internal',
+  customJson: '',
+};
+
+export type ColormapContext = ColormapState & { dispatch: Dispatch<ColormapAction> };

--- a/hooks/useCOGViewer.ts
+++ b/hooks/useCOGViewer.ts
@@ -1,7 +1,12 @@
-import { useState, useRef, useCallback } from 'react';
+import { useState, useReducer, useRef, useCallback } from 'react';
 import { App } from 'antd';
 import { VEDA_BACKEND_URL } from '@/config/env';
 import { Map as LeafletMap } from 'leaflet';
+import {
+  type ColormapType,
+  colormapReducer,
+  initialColormapState,
+} from '@/components/COGViewer/colormapReducer';
 
 type RendersType = {
   bidx?: number[];
@@ -14,8 +19,6 @@ type RendersType = {
   assets?: string[];
   title?: string;
 };
-
-type ColormapType = 'named' | 'custom';
 
 type COGMetadata = {
   band_descriptions?: Array<[string | number, string]>;
@@ -97,9 +100,7 @@ export const useCOGViewer = () => {
   const [metadata, setMetadata] = useState<COGMetadata | null>(null);
   const [selectedBands, setSelectedBands] = useState<number[]>([]);
   const [rescale, setRescale] = useState<[number | null, number | null][]>([]);
-  const [selectedColormap, setSelectedColormap] = useState<string>('Internal');
-  const [colormapType, setColormapType] = useState<ColormapType>('named');
-  const [customColormapJson, setCustomColormapJson] = useState<string>('');
+  const [colormap, dispatchColormap] = useReducer(colormapReducer, initialColormapState);
   const [colorFormula, setColorFormula] = useState<string | null>(null);
   const [selectedResampling, setSelectedResampling] = useState<string | null>(
     null
@@ -243,9 +244,11 @@ export const useCOGViewer = () => {
           initialSelectedColormap = parsedRenders.colormap_name;
         }
 
-        setColormapType(initialColormapType);
-        setCustomColormapJson(initialCustomColormapJson);
-        setSelectedColormap(initialSelectedColormap);
+        dispatchColormap({ type: 'INIT', state: {
+          type: initialColormapType,
+          selected: initialSelectedColormap,
+          customJson: initialCustomColormapJson,
+        }});
         setColorFormula(parsedRenders.color_formula || null);
         setSelectedResampling(parsedRenders.resampling || null);
         setNoDataValue(parsedRenders.nodata || null);
@@ -287,12 +290,7 @@ export const useCOGViewer = () => {
     setSelectedBands,
     rescale,
     setRescale,
-    selectedColormap,
-    setSelectedColormap,
-    colormapType,
-    setColormapType,
-    customColormapJson,
-    setCustomColormapJson,
+    colormap: { ...colormap, dispatch: dispatchColormap },
     colorFormula,
     setColorFormula,
     selectedResampling,


### PR DESCRIPTION
Taking a look at the `useCogViewer` hook, I noticed that it exposes a good amount of state getters and setters so I was thinking we could probably benefit from a reducer here ? that way instead of exposing/managing multiple pieces of state for just colormap, the code just interfaces with one state reducer which I thought was more simple.

This is probably a pattern that wont scale the best with more incrementations of singular pieces of state though because its unnecessary (like `selectedBands` or `rescale`). I just thought it would be better for colormaps since there is multiple pieces of state that is being exposed/updated. I had another idea of a form reducer here for the `useCogViewer` hook but that might be worth exploring later as it would introduce too much currently. 

@stephenkilbourn thoughts ? (I'm fine with whichever direction! I thought your PR and current implementation was already good too 🚀 )