### PR TITLE
fix: bring summaries in line with STAC spec

### DIFF
--- a/FormSchemas/collections/collectionSchema.json
+++ b/FormSchemas/collections/collectionSchema.json
@@ -150,9 +150,7 @@
             "title": "Set of values",
             "type": "array",
             "minItems": 1,
-            "items": {
-              "type": "string"
-            }
+            "items": {}
           }
         ]
       }

--- a/components/rjsf-components/SummariesManager.tsx
+++ b/components/rjsf-components/SummariesManager.tsx
@@ -88,9 +88,13 @@ const SummariesManager: React.FC<SummariesManagerProps> = ({
       case SUMMARY_TYPES.SET:
         return (
           <div>
-            {(data as unknown[]).map((v, i) => (
-              <Tag key={i}>{String(v) || '(empty)'}</Tag>
-            ))}
+            {(data as unknown[]).map((v, i) => {
+              const label =
+                v !== null && typeof v === 'object'
+                  ? JSON.stringify(v)
+                  : String(v);
+              return <Tag key={i}>{label || '(empty)'}</Tag>;
+            })}
           </div>
         );
       case SUMMARY_TYPES.RANGE:


### PR DESCRIPTION
The [STAC collections spec ](https://github.com/radiantearth/stac-spec/blob/master/collection-spec/collection-spec.md#summaries)supports, for summaries, set of all distinct values in an array. We previously required these to be strings, but that doesn't work for some collections which are otherwise valid STAC. 

I'm proposing a loosened schema for the raw-collection input. I also adjusted the form to show stringified nested values, instead of [object Object], where applicable.