### PR TITLE
fix: add scroll to /edit-dataset and /edit-collection columns

### DIFF
--- a/components/ingestion/PendingIngestList.tsx
+++ b/components/ingestion/PendingIngestList.tsx
@@ -101,6 +101,7 @@ const PendingIngestList: React.FC<PendingIngestListProps> = ({
       getIngestTenant(ingest)?.toLowerCase() === 'public'
   );
 
+  const columnSize = tenants.length > 1 ? 'default' : 'full'; // if more then one tenant, default is set to 1/4 width on desktop
   return (
     <>
       <Title level={3} style={{ marginBottom: 24 }}>
@@ -108,32 +109,23 @@ const PendingIngestList: React.FC<PendingIngestListProps> = ({
       </Title>
 
       <Row gutter={[16, 16]}>
-        {visibleTenants.length > 0 &&
-          visibleTenants.map((tenant: string) => {
+        {tenants.length > 0 &&
+          tenants.map((tenant: string) => {
             const tenantIngests: IngestPullRequest[] = allIngests.filter(
               (ingest: IngestPullRequest) => getIngestTenant(ingest) === tenant
             );
-
+            const publicTenant: boolean = tenant.toLowerCase() == 'public';
             return (
               <IngestColumn
-                key={tenant}
-                title={`Tenant: ${tenant}`}
-                ingests={tenantIngests}
+                key={publicTenant ? 'public' : tenant}
+                title={publicTenant ? 'Public' : `Tenant: ${tenant}`}
+                ingests={publicTenant ? publicIngests : tenantIngests}
                 onIngestSelect={onIngestSelect}
                 testId={`tenant-column-${tenant}`}
+                columnSize={columnSize}
               />
             );
           })}
-
-        {publicIngests.length > 0 && (
-          <IngestColumn
-            key="public"
-            title="Public"
-            ingests={publicIngests}
-            onIngestSelect={onIngestSelect}
-            testId="tenant-column-public"
-          />
-        )}
       </Row>
 
       {apiError && (

--- a/components/ingestion/PendingIngestList.tsx
+++ b/components/ingestion/PendingIngestList.tsx
@@ -121,7 +121,7 @@ const PendingIngestList: React.FC<PendingIngestListProps> = ({
                 title={publicTenant ? 'Public' : `Tenant: ${tenant}`}
                 ingests={publicTenant ? publicIngests : tenantIngests}
                 onIngestSelect={onIngestSelect}
-                testId={`tenant-column-${tenant}`}
+                testId={publicTenant ? "tenant-column-public" : `tenant-column-${tenant}`}
                 columnSize={columnSize}
               />
             );

--- a/components/ingestion/PendingIngestList.tsx
+++ b/components/ingestion/PendingIngestList.tsx
@@ -101,7 +101,8 @@ const PendingIngestList: React.FC<PendingIngestListProps> = ({
       getIngestTenant(ingest)?.toLowerCase() === 'public'
   );
 
-  const columnSize = tenants.length > 1 ? 'default' : 'full'; // if more then one tenant, default is set to 1/4 width on desktop
+  const columnSize = visibleTenants.length > 0 ? 'default' : 'full'; // if more then one tenant, default is set to 1/4 width on desktop
+
   return (
     <>
       <Title level={3} style={{ marginBottom: 24 }}>
@@ -109,23 +110,34 @@ const PendingIngestList: React.FC<PendingIngestListProps> = ({
       </Title>
 
       <Row gutter={[16, 16]}>
-        {tenants.length > 0 &&
-          tenants.map((tenant: string) => {
+        {visibleTenants.length > 0 &&
+          visibleTenants.map((tenant: string) => {
             const tenantIngests: IngestPullRequest[] = allIngests.filter(
               (ingest: IngestPullRequest) => getIngestTenant(ingest) === tenant
             );
-            const publicTenant: boolean = tenant.toLowerCase() == 'public';
+
             return (
               <IngestColumn
-                key={publicTenant ? 'public' : tenant}
-                title={publicTenant ? 'Public' : `Tenant: ${tenant}`}
-                ingests={publicTenant ? publicIngests : tenantIngests}
+                key={tenant}
+                title={`Tenant: ${tenant}`}
+                ingests={tenantIngests}
                 onIngestSelect={onIngestSelect}
-                testId={publicTenant ? "tenant-column-public" : `tenant-column-${tenant}`}
+                testId={`tenant-column-${tenant}`}
                 columnSize={columnSize}
               />
             );
           })}
+
+        {publicIngests.length > 0 && (
+          <IngestColumn
+            key="public"
+            title="Public"
+            ingests={publicIngests}
+            onIngestSelect={onIngestSelect}
+            testId="tenant-column-public"
+            columnSize={columnSize}
+          />
+        )}
       </Row>
 
       {apiError && (

--- a/components/ingestion/_components/IngestColumn.tsx
+++ b/components/ingestion/_components/IngestColumn.tsx
@@ -6,6 +6,7 @@ interface IngestColumnProps {
   ingests: IngestPullRequest[];
   onIngestSelect: (ref: string, title: string) => void;
   testId?: string;
+  columnSize?: 'default' | 'full';
 }
 
 export const IngestColumn: React.FC<IngestColumnProps> = ({
@@ -13,9 +14,10 @@ export const IngestColumn: React.FC<IngestColumnProps> = ({
   ingests,
   onIngestSelect,
   testId,
+  columnSize,
 }) => {
   return (
-    <Col xs={24} sm={12} md={8} lg={6} data-testid={testId}>
+    <Col {...(columnSize == 'full' ? {xs: 24, sm: 24, md: 24, lg: 24} : {xs: 24, sm: 12, md: 8, lg: 6})} data-testid={testId}>
       <Card
         title={title}
         style={{
@@ -23,6 +25,7 @@ export const IngestColumn: React.FC<IngestColumnProps> = ({
           borderRadius: 8,
           boxShadow: '0 2px 8px #f0f1f2',
         }}
+        styles={{ body: { maxHeight: '600px', overflowY: 'auto' } }}
       >
         <List
           dataSource={ingests}

--- a/components/ingestion/_components/IngestColumn.tsx
+++ b/components/ingestion/_components/IngestColumn.tsx
@@ -17,7 +17,12 @@ export const IngestColumn: React.FC<IngestColumnProps> = ({
   columnSize,
 }) => {
   return (
-    <Col {...(columnSize == 'full' ? {xs: 24, sm: 24, md: 24, lg: 24} : {xs: 24, sm: 12, md: 8, lg: 6})} data-testid={testId}>
+    <Col
+      {...(columnSize == 'full'
+        ? { xs: 24, sm: 24, md: 24, lg: 24 }
+        : { xs: 24, sm: 12, md: 8, lg: 6 })}
+      data-testid={testId}
+    >
       <Card
         title={title}
         style={{


### PR DESCRIPTION
Related Issue: https://github.com/NASA-IMPACT/veda-ingest-ui/issues/283

Changes: **UI fixes only**
* Added maxHeight and overflow of auto to IngestColumns (`/edit-dataset` & `/edit-collection`)
* If one tenant like `Public` just set column to whole width otherwise default to original
* cleaned up some logic

Demo of Changes: https://www.loom.com/share/43f02374905b468aa0e4404f6a0fd705