### PR TITLE
ci: add OSSF scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,43 @@
+name: OSSF Scorecard
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "30 16 * * 1" # Monday 10:30/11:30 CT
+
+permissions: read-all # Default all to readonly
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # Allow upload to Security dashboard
+      id-token: write # Access GitHub's OIDC token to verify authenticity of result for publish
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
>[!NOTE]
>See https://github.com/NASA-IMPACT/veda-keycloak/pull/253 for more detail on OSSF Scorecard + Dependabot configs, removed repeated detail to help reviewers and better highlight repo-specific deltas.

---

- [OSSF Scorecard](https://github.com/ossf/scorecard-action) added


**NOTE**: Dependabot was _not_ updated to include runtime dependency updates, eg `npm`/`yarn`, since it sounded like existing tooling may already cover - please correct me if that's wrong ! (cc: @sandrahoang686)