### PR TITLE
feat: Add amplify previews workflow & remove visual nesting of input fields

### DIFF
--- a/.github/workflows/amplify-pr-preview.yml
+++ b/.github/workflows/amplify-pr-preview.yml
@@ -12,7 +12,6 @@ permissions:
   pull-requests: write # Required to post/update comments
 
 env:
-  AMPLIFY_APP_ID: dzi1klnpemkf3
   AWS_REGION: us-west-2
   # Amplify branch subdomains lowercase the branch name and replace '/' with '-'.
   BRANCH_NAME: ${{ github.head_ref }}
@@ -24,6 +23,11 @@ jobs:
     # contributor's PR could trigger an AWS build on this public repo.
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    environment: veda
+    env:
+      AMPLIFY_APP_ID: ${{ vars.AMPLIFY_APP_ID }}
+      # The IAM role to assume to deploy the preview.
+      AMPLIFY_PREVIEW_ROLE: ${{ vars.AMPLIFY_PREVIEW_ROLE }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -31,7 +35,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::853558080719:role/GitHubActionsAmplifyPreviewRole
+          role-to-assume: "$AMPLIFY_PREVIEW_ROLE"
           aws-region: ${{ env.AWS_REGION }}
 
       # Handle PR Open or Sync: Deploy Preview

--- a/.github/workflows/amplify-pr-preview.yml
+++ b/.github/workflows/amplify-pr-preview.yml
@@ -11,6 +11,12 @@ permissions:
   contents: read    # Required for checking out the repository
   pull-requests: write # Required to post/update comments
 
+# Cancel a stale run for this PR when a new commit is pushed, so we don't
+# race a previous run to start/delete Amplify jobs on the same branch.
+concurrency:
+  group: amplify-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 env:
   AWS_REGION: us-west-2
   # Amplify branch subdomains lowercase the branch name and replace '/' with '-'.
@@ -48,6 +54,15 @@ jobs:
           # Check if the preview branch already exists in Amplify, if not, create it
           aws amplify get-branch --app-id "$APP_ID" --branch-name "$BRANCH_NAME" || \
           aws amplify create-branch --app-id "$APP_ID" --branch-name "$BRANCH_NAME" --stage PULL_REQUEST
+
+          # Amplify rejects StartJob if the branch already has a pending/running job
+          # (e.g. a rapid follow-up push). Stop it first so the new job can start.
+          ACTIVE_JOB_ID=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name "$BRANCH_NAME" \
+            --query "jobSummaries[?status=='PENDING' || status=='PROVISIONING' || status=='RUNNING'].jobId | [0]" \
+            --output text)
+          if [ -n "$ACTIVE_JOB_ID" ] && [ "$ACTIVE_JOB_ID" != "None" ]; then
+            aws amplify stop-job --app-id "$APP_ID" --branch-name "$BRANCH_NAME" --job-id "$ACTIVE_JOB_ID"
+          fi
 
           # Trigger the build job
           JOB_ID=$(aws amplify start-job --app-id "$APP_ID" --branch-name "$BRANCH_NAME" \

--- a/.github/workflows/amplify-pr-preview.yml
+++ b/.github/workflows/amplify-pr-preview.yml
@@ -1,0 +1,141 @@
+name: AWS Amplify PR Previews
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: [opened, synchronize, reopened, closed]
+
+permissions:
+  id-token: write   # Required for AWS OIDC authentication
+  contents: read    # Required for checking out the repository
+  pull-requests: write # Required to post/update comments
+
+env:
+  AMPLIFY_APP_ID: dzi1klnpemkf3
+  AWS_REGION: us-west-2
+  # Amplify branch subdomains lowercase the branch name and replace '/' with '-'.
+  BRANCH_NAME: ${{ github.head_ref }}
+
+jobs:
+  manage-preview:
+    # Skip PRs from forks: the IAM role's OIDC trust condition matches on the
+    # base repo regardless of head repo, so without this guard any external
+    # contributor's PR could trigger an AWS build on this public repo.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::853558080719:role/GitHubActionsAmplifyPreviewRole
+          aws-region: ${{ env.AWS_REGION }}
+
+      # Handle PR Open or Sync: Deploy Preview
+      - name: Deploy Amplify PR Preview
+        id: deploy
+        if: github.event.action != 'closed'
+        run: |
+          APP_ID="$AMPLIFY_APP_ID"
+
+          # Check if the preview branch already exists in Amplify, if not, create it
+          aws amplify get-branch --app-id "$APP_ID" --branch-name "$BRANCH_NAME" || \
+          aws amplify create-branch --app-id "$APP_ID" --branch-name "$BRANCH_NAME" --stage PULL_REQUEST
+
+          # Trigger the build job
+          JOB_ID=$(aws amplify start-job --app-id "$APP_ID" --branch-name "$BRANCH_NAME" \
+            --job-type RELEASE --query 'jobSummary.jobId' --output text)
+          echo "job_id=$JOB_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Post initial preview comment
+        if: github.event.action != 'closed'
+        uses: actions/github-script@v7
+        id: initial-comment
+        with:
+          script: |
+            const marker = '<!-- amplify-pr-preview -->';
+            const branch = process.env.BRANCH_NAME.toLowerCase().replace(/\//g, '-');
+            const previewUrl = `https://${branch}.${process.env.AMPLIFY_APP_ID}.amplifyapp.com`;
+            const body = `${marker}\n🔄 **Amplify preview building...**\n\nPreview URL (not live yet): ${previewUrl}\n\n_This comment will update when the build completes._`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+            });
+            const existing = comments.find((c) => c.body.includes(marker));
+
+            let commentId;
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+              commentId = existing.id;
+            } else {
+              const { data: comment } = await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body,
+              });
+              commentId = comment.id;
+            }
+            core.setOutput('comment_id', commentId);
+            core.setOutput('preview_url', previewUrl);
+
+      - name: Wait for Amplify build
+        if: github.event.action != 'closed'
+        id: wait-build
+        env:
+          JOB_ID: ${{ steps.deploy.outputs.job_id }}
+        run: |
+          MAX_ATTEMPTS=20
+          ATTEMPT=0
+          STATUS="PENDING"
+          while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
+            STATUS=$(aws amplify get-job --app-id "$AMPLIFY_APP_ID" \
+              --branch-name "$BRANCH_NAME" --job-id "$JOB_ID" \
+              --query 'job.summary.status' --output text)
+            echo "Attempt $ATTEMPT: $STATUS"
+            if [ "$STATUS" = "SUCCEED" ] || [ "$STATUS" = "FAILED" ] || [ "$STATUS" = "CANCELLED" ]; then
+              break
+            fi
+            ATTEMPT=$((ATTEMPT + 1))
+            sleep 30
+          done
+          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
+
+      - name: Update preview comment
+        if: github.event.action != 'closed'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- amplify-pr-preview -->';
+            const status = '${{ steps.wait-build.outputs.status }}';
+            const previewUrl = '${{ steps.initial-comment.outputs.preview_url }}';
+            const consoleUrl = `https://console.aws.amazon.com/amplify/home?region=${process.env.AWS_REGION}#/${process.env.AMPLIFY_APP_ID}`;
+            const messages = {
+              SUCCEED: `${marker}\n✅ **Amplify preview ready**\n\n🔗 [Open preview](${previewUrl})\n\`${previewUrl}\``,
+              FAILED: `${marker}\n❌ **Amplify build failed**\n\nCheck the [Amplify console](${consoleUrl}) for logs.`,
+              CANCELLED: `${marker}\n⚠️ **Amplify build was cancelled.**`,
+            };
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: ${{ steps.initial-comment.outputs.comment_id }},
+              body: messages[status] || `${marker}\n⏱️ **Build taking longer than expected.**\n\nExpected URL (may not be ready yet): ${previewUrl}`,
+            });
+
+      # Handle PR Close: Clean up resource
+      - name: Delete Amplify PR Preview
+        if: github.event.action == 'closed'
+        run: |
+          APP_ID="$AMPLIFY_APP_ID"
+
+          aws amplify delete-branch --app-id "$APP_ID" --branch-name "$BRANCH_NAME"

--- a/.github/workflows/amplify-pr-preview.yml
+++ b/.github/workflows/amplify-pr-preview.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: "$AMPLIFY_PREVIEW_ROLE"
+          role-to-assume: ${{ vars.AMPLIFY_PREVIEW_ROLE }}
           aws-region: ${{ env.AWS_REGION }}
 
       # Handle PR Open or Sync: Deploy Preview

--- a/app/globals.css
+++ b/app/globals.css
@@ -70,6 +70,14 @@ div[id='root_assets'] {
   box-shadow: 0px 3px 15px rgba(0, 0, 0, 0.2);
 }
 
+
+/* Remove nesting of the visual CSS boxes for nested object input fields */
+fieldset[id^='root_'].object-field-template-nested {
+  padding: 0;
+  border-radius: 0;
+  box-shadow: none;
+}
+
 label[title='Discovery Items'],
 label[title='Links'],
 label[title='Item Assets'],

--- a/components/rjsf-components/ObjectFieldTemplate.tsx
+++ b/components/rjsf-components/ObjectFieldTemplate.tsx
@@ -136,6 +136,8 @@ export default function ObjectFieldTemplate<
     return <DiscoveryItemObjectFieldTemplate {...props} />;
   }
 
+  const isNestedInputObject = fieldPathId.path.length > 1;
+
   return (
     <ConfigConsumer>
       {(configProps: ConfigConsumerProps) => {
@@ -149,7 +151,12 @@ export default function ObjectFieldTemplate<
 
         return (
           <>
-            <fieldset id={fieldPathId.$id}>
+            <fieldset
+              id={fieldPathId.$id}
+              className={
+                isNestedInputObject ? 'object-field-template-nested' : undefined
+              }
+            >
               <Row gutter={rowGutter}>
                 {title && (
                   <Col className={labelColClassName} span={24}>

--- a/docs/amplify-preview.md
+++ b/docs/amplify-preview.md
@@ -1,0 +1,22 @@
+# Amplify PR Previews
+
+This document explains how the `amplify-pr-preview.yml` GitHub Actions workflow builds and tears down AWS Amplify preview deployments for pull requests, and how it authenticates to AWS.
+
+## Purpose
+
+On every PR against `main`, an Amplify branch deployment is spun up. When the PR closes, the workflow deletes the Amplify branch to avoid leaking stale preview environments.
+
+Previews are only created for the **veda-ingest-ui** app itself and not for the other instances.
+
+## Required Configuration
+
+The workflow relies on these values, sourced from the `veda` GitHub environment as repository variables.
+
+- `AMPLIFY_APP_ID` — the Amplify app ID that previews are created under.
+- `AMPLIFY_PREVIEW_ROLE` — the ARN of the IAM role assumed via OIDC to call the Amplify API.
+
+## IAM Role and OIDC Trust
+
+The workflow authenticates to AWS using `aws-actions/configure-aws-credentials`, assuming the role at `vars.AMPLIFY_PREVIEW_ROLE` via GitHub's OIDC identity provider.
+
+`GitHubActionsAmplifyPreviewRole` IAM Role was created in the **UAH** AWS account from an existing `token.actions.githubusercontent.com` OIDC provider. Its trust policy allows GitHub Actions runs from this repository to assume it, and its permissions policy is scoped to the Amplify actions the workflow needs (`get-branch`, `create-branch`, `start-job`, `get-job`, `delete-branch`) against the `veda-ingest-ui` Amplify app.

--- a/docs/amplify-preview.md
+++ b/docs/amplify-preview.md
@@ -19,4 +19,4 @@ The workflow relies on these values, sourced from the `veda` GitHub environment 
 
 The workflow authenticates to AWS using `aws-actions/configure-aws-credentials`, assuming the role at `vars.AMPLIFY_PREVIEW_ROLE` via GitHub's OIDC identity provider.
 
-`GitHubActionsAmplifyPreviewRole` IAM Role was created in the **UAH** AWS account from an existing `token.actions.githubusercontent.com` OIDC provider. Its trust policy allows GitHub Actions runs from this repository to assume it, and its permissions policy is scoped to the Amplify actions the workflow needs (`get-branch`, `create-branch`, `start-job`, `get-job`, `delete-branch`) against the `veda-ingest-ui` Amplify app.
+`GitHubActionsAmplifyPreviewRole` IAM Role was created in the **UAH** AWS account from an existing `token.actions.githubusercontent.com` OIDC provider. Its trust policy allows GitHub Actions runs from this repository to assume it, and its permissions policy is scoped to the Amplify actions the workflow needs (`get-branch`, `create-branch`, `start-job`, `get-job`, `list-jobs`, `stop-job`, `delete-branch`) against the `veda-ingest-ui` Amplify app.


### PR DESCRIPTION
**Context:**
Currently when making changes to ingest-ui and opening a PR to `main`, the only way to validate changes is manually. So I wanted to hook up Amplify to create PR previews when PRs are opened against `main`. But because this repo is `public` it wasn't as easy as just switching the `enable` button in AWS to allow previews. I had to create an IAM role  `GitHubActionsAmplifyPreviewRole` in UAH from an existing `token.actions.githubusercontent` OIDC provider to allow amplify to create these previews. Previews are only created for the `veda-ingest-ui` app and not for the other instance versions (eic & disasters). Hoping this can help make previewing and reviewing changes easier 🙇🏼 
**Resources:** https://aws.amazon.com/blogs/security/use-iam-roles-to-connect-github-actions-to-actions-in-aws/
**Changes:**
* UI update - remove nested visual boxes on nested input objects with in json schema
* Added workflow to generate amplify previews

**Before:**
<img width="1304" height="663" alt="Screenshot 2026-07-13 at 2 32 43 PM" src="https://github.com/user-attachments/assets/ba20205a-a740-4867-a28e-6e7640cc0cae" />
**After:**
<img width="1254" height="622" alt="Screenshot 2026-07-13 at 2 33 05 PM" src="https://github.com/user-attachments/assets/b283d0d9-809f-49e6-b4da-fc1e119ee2ee" />
